### PR TITLE
Fix underscores in column names for apa_table.latex()

### DIFF
--- a/R/apa_table.R
+++ b/R/apa_table.R
@@ -215,6 +215,9 @@ apa_table.latex <- function(
   current_chunk <- knitr::opts_current$get("label")
   if(!is.null(current_chunk)) caption <- paste0("\\label{tab:", current_chunk, "}", caption)
 
+  # Escape underscores
+  colnames(x) <- gsub("_", "\\_", names(x), fixed = TRUE)
+
   # Center title row
   colnames(x)[-1] <- paste0("\\multicolumn{1}{c}{", colnames(x), "}")[-1]
 

--- a/R/apa_table.R
+++ b/R/apa_table.R
@@ -215,8 +215,13 @@ apa_table.latex <- function(
   current_chunk <- knitr::opts_current$get("label")
   if(!is.null(current_chunk)) caption <- paste0("\\label{tab:", current_chunk, "}", caption)
 
-  # Escape underscores
-  colnames(x) <- gsub("_", "\\_", names(x), fixed = TRUE)
+  # Escape underscores and percentages in whole table
+  colnames(x) <- gsub("_", "\\_", colnames(x), fixed = TRUE)
+  rownames(x) <- gsub("_", "\\_", rownames(x), fixed = TRUE)
+  x[] <- lapply(x, function(x) gsub("_", "\\_", x, fixed = TRUE))
+  colnames(x) <- gsub("%", "\\%", colnames(x), fixed = TRUE)
+  rownames(x) <- gsub("%", "\\%", rownames(x), fixed = TRUE)
+  x[] <- lapply(x, function(x) gsub("%", "\\%", x, fixed = TRUE))
 
   # Center title row
   colnames(x)[-1] <- paste0("\\multicolumn{1}{c}{", colnames(x), "}")[-1]


### PR DESCRIPTION
This fixes issue #116