### PR TITLE
Fixes #126.

### DIFF
--- a/inst/rmarkdown/templates/apa6/resources/apa6.tex
+++ b/inst/rmarkdown/templates/apa6/resources/apa6.tex
@@ -228,9 +228,7 @@ $else$ % If no author_note is defined give only author information if available
       $for(author)$
         $if(author.corresponding)$
           \authornote{
-          Correspondence concerning this article should be addressed to $author.name$
-          $if(author.address)$, $author.address$ $endif$.
-          $if(author.email)$ E-mail: $author.email$ $endif$
+            Correspondence concerning this article should be addressed to $author.name$$if(author.address)$, $author.address$$endif$.$if(author.email)$ E-mail: $author.email$$endif$
           }
         $endif$
       $endfor$


### PR DESCRIPTION
This one fixes #126: On the title page, there was some extraneous whitespace included in the sentence "Correspondence concerning this article..." if no author note was provided in the YAML header. This was a bug in the apa6.tex template.