### PR TITLE
This is a minor improvement to using `relevel` on `annotated_factor`s…

### DIFF
--- a/R/annotated_data.R
+++ b/R/annotated_data.R
@@ -741,7 +741,7 @@ setMethod(
 #' @seealso \code{\link{relevel}}
 #' @details Currently, two methods for reordering the levels of an \code{annotated_factor} are implemented:
 #' The \code{annotated_factor,character}-method reorders the levels according to the ordering in a character vector \code{ref}.
-#' The \code{annotated_factor,integer}-method reorders the levels according to their position within the vector of levels
+#' The \code{annotated_factor,numeric}-method reorders the levels according to their position within the vector of levels
 #' (as would be returned by \code{levels}).
 #'
 #' @rdname relevel_annotated
@@ -773,7 +773,7 @@ setMethod(
 
 setMethod(
   f = "relevel"
-  , signature = c(x = "annotated_factor", ref = "integer")
+  , signature = c(x = "annotated_factor", ref = "numeric")
   , definition = function(x, ref){
     # reorder integer vector:
     index <- 1:length(x@levels)

--- a/man/relevel_annotated.Rd
+++ b/man/relevel_annotated.Rd
@@ -3,12 +3,12 @@
 \docType{methods}
 \name{relevel,annotated_factor,character-method}
 \alias{relevel,annotated_factor,character-method}
-\alias{relevel,annotated_factor,integer-method}
+\alias{relevel,annotated_factor,numeric-method}
 \title{Reorder Levels of Annotated Factor}
 \usage{
 \S4method{relevel}{annotated_factor,character}(x, ref)
 
-\S4method{relevel}{annotated_factor,integer}(x, ref)
+\S4method{relevel}{annotated_factor,numeric}(x, ref)
 }
 \arguments{
 \item{x}{An object of class \code{annotated_factor}.}


### PR DESCRIPTION
…. The reference level can now be specified by character, integer, or double (before, double was not supported)