### PR TITLE
Bugfix, solves #201

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^\.travis\.yml
 ^example$
 ^inst/rmarkdown/templates/revision_letter$
+_config.yml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
   methods
 Suggests:
   car,
+  carData,
   afex,
   lsmeans,
   multcomp,

--- a/R/arrange_anova.R
+++ b/R/arrange_anova.R
@@ -157,10 +157,22 @@ arrange_anova.summary.Anova.mlm <- function(x, correction = "GG") {
   }
 
   # Rearrange and rename columns
-  univariate_names <- c("SS", "num Df", "Error SS", "den Df", "F", "Pr(>F)")
+  renamers <- c(
+    "SS" = "sumsq"
+    , "Sum Sq" = "sumsq"
+    , "num Df" = "df"
+    , "Error SS" = "sumsq_err"
+    , "den Df" = "df_res"
+    , "F" = "statistic"
+    , "F value" = "statistic"
+    , "Pr(>F)" = "p.value"
+  )
+
+  colnames(variance_table) <- renamers[colnames(variance_table)]
+
   broom_names <- c("sumsq", "df", "sumsq_err", "df_res", "statistic", "p.value")
-  variance_table <- variance_table[, univariate_names]
-  colnames(variance_table) <- broom_names
+  variance_table <- variance_table[, broom_names]
+
 
   variance_table$term <- rownames(variance_table)
   variance_table <- data.frame(variance_table, row.names = NULL)

--- a/tests/testthat/test_apa_print_anova.R
+++ b/tests/testthat/test_apa_print_anova.R
@@ -362,7 +362,7 @@ test_that(
 test_that(
   "Levene test"
   , {
-    levene_test <- car::leveneTest(conformity ~ fcategory * partner.status, data = car::Moore)
+    levene_test <- car::leveneTest(conformity ~ fcategory * partner.status, data = carData::Moore)
     levene_test_output <- apa_print(levene_test)
     expect_is(levene_test_output, "list")
     expect_equal(names(levene_test_output), container_names)


### PR DESCRIPTION
- changed the renaming of columns in apa_print.summary.Anova.mlm to a more flexible (broom-inspired) coding
- added support for new `afex_ov` objects to `apa_factorial_plot()`
- changed the source of the Moore dataset in tests (as it moved from `car` to `carData`)
- added `_config.yml` to `.Rbuildignore`