### PR TITLE
Proper NA handling for within-subjects CIs and plot functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,5 +43,5 @@ Suggests:
 License: MIT + file LICENSE
 LazyData: yes
 Encoding: UTF-8
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.0
 VignetteBuilder: knitr

--- a/R/apa_barplot.R
+++ b/R/apa_barplot.R
@@ -55,6 +55,7 @@ apa_barplot.default <- function(
   , level = 0.95
   , fun_aggregate = mean
   , na.rm = TRUE
+  , use = "all.obs"
   , reference = 0
   , intercept = NULL
   , args_x_axis = NULL
@@ -80,6 +81,7 @@ apa_barplot.default <- function(
       , level = level
       , fun_aggregate = substitute(fun_aggregate)
       , na.rm = na.rm
+      , use = use
       , reference = reference
       , intercept = intercept
       , args_x_axis = args_x_axis

--- a/R/apa_beeplot.R
+++ b/R/apa_beeplot.R
@@ -55,6 +55,7 @@ apa_beeplot.default <- function(
   , level = 0.95
   , fun_aggregate = mean
   , na.rm = TRUE
+  , use = "all.obs"
   , reference = 0
   , intercept = NULL
   , args_x_axis = NULL
@@ -82,6 +83,7 @@ apa_beeplot.default <- function(
       , level = level
       , fun_aggregate = substitute(fun_aggregate)
       , na.rm = na.rm
+      , use = use
       , intercept = intercept
       , args_x_axis = args_x_axis
       , args_y_axis = args_y_axis

--- a/R/apa_beeplot.R
+++ b/R/apa_beeplot.R
@@ -56,7 +56,6 @@ apa_beeplot.default <- function(
   , fun_aggregate = mean
   , na.rm = TRUE
   , use = "all.obs"
-  , reference = 0
   , intercept = NULL
   , args_x_axis = NULL
   , args_y_axis = NULL

--- a/R/apa_factorial_plot.R
+++ b/R/apa_factorial_plot.R
@@ -15,6 +15,8 @@
 #' @param fun_aggregate Closure. The function that will be used to aggregate observations within subjects and factors
 #'    before calculating descriptive statistics for each cell of the design. Defaults to \code{mean}.
 #' @param na.rm Logical. Specifies if missing values are removed. Defaults to \code{TRUE}.
+#' @param use Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
+#'    Possible options are \code{"all.obs"} or \code{"complete.obs"}.
 #' @param reference Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.
 #' @param intercept Numeric. Adds a horizontal line at height \code{intercept} to the plot. Can be either a single value or a matrix. For the matrix
 #'    case, multiple lines are drawn, where the dimensions of the matrix determine the number of lines to be drawn.
@@ -90,6 +92,7 @@ apa_factorial_plot.default <- function(
   , level = 0.95
   , fun_aggregate = mean
   , na.rm = TRUE
+  , use = "all.obs"
   , reference = 0
   , intercept = NULL
   , args_x_axis = NULL
@@ -120,6 +123,10 @@ apa_factorial_plot.default <- function(
   validate(level, check_class = "numeric", check_range = c(0,1))
   validate(fun_aggregate, check_class = "function", check_length = 1, check_NA = FALSE)
   validate(na.rm, check_class = "logical", check_length = 1)
+  validate(use, check_class = "character", check_length = 1)
+  if(!use%in%c("all.obs", "complete.obs")) {
+    stop('Parameter `use` must be either "all.obs" or "complete.obs".')
+  }
   validate(data, check_class = "data.frame", check_cols = c(id, dv, factors), check_NA = FALSE)
   if(!is.null(intercept)) validate(intercept, check_mode = "numeric", check_NA = FALSE)
   if(!is.null(args_x_axis)) validate(args_x_axis, check_class = "list")
@@ -279,6 +286,15 @@ apa_factorial_plot.default <- function(
     }
   } else {
     aggregated <- data
+  }
+
+  # ----------------------------------------------------------------------------
+  # Check if there are incomplete observations and eventually remove them
+  if(use=="complete.obs") {
+    excluded_id <- sort(unique(aggregated[[id]][is.na(aggregated[[dv]])]))
+
+    data <- data[!data[[id]]%in%excluded_id, ]
+    aggregated <- aggregated[!aggregated[[id]]%in%excluded_id, ]
   }
 
   ## Calculate central tendencies ----------------------------------------------

--- a/R/apa_factorial_plot.R
+++ b/R/apa_factorial_plot.R
@@ -17,7 +17,7 @@
 #' @param na.rm Logical. Specifies if missing values are removed. Defaults to \code{TRUE}.
 #' @param use Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
 #'    Possible options are \code{"all.obs"} or \code{"complete.obs"}.
-#' @param reference Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.
+#' @param reference Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to \code{0}.
 #' @param intercept Numeric. Adds a horizontal line at height \code{intercept} to the plot. Can be either a single value or a matrix. For the matrix
 #'    case, multiple lines are drawn, where the dimensions of the matrix determine the number of lines to be drawn.
 #' @param plot Character. A vector specifying which elements of the plot should be plotted. Available options are

--- a/R/apa_factorial_plot.R
+++ b/R/apa_factorial_plot.R
@@ -291,10 +291,17 @@ apa_factorial_plot.default <- function(
   # ----------------------------------------------------------------------------
   # Check if there are incomplete observations and eventually remove them
   if(use=="complete.obs") {
-    excluded_id <- sort(unique(aggregated[[id]][is.na(aggregated[[dv]])]))
-
-    data <- data[!data[[id]]%in%excluded_id, ]
-    aggregated <- aggregated[!aggregated[[id]]%in%excluded_id, ]
+    # excluded_id <- sort(unique(aggregated[[id]][is.na(aggregated[[dv]])]))
+    #
+    # data <- data[!data[[id]]%in%excluded_id, ]
+    # aggregated <- aggregated[!aggregated[[id]]%in%excluded_id, ]
+    tmp <- determine_within_between(data = aggregated, id = id, factors = factors)
+    aggregated <- complete_observations(data = aggregated, id = id, within = tmp$within, dv = dv)
+    removed_cases <- unlist(attributes(aggregated)[c("removed_cases_implicit_NA", "removed_cases_explicit_NA")])
+    if(!is.null(removed_cases)) {
+      excluded_id <- sort(unique(removed_cases))
+      data <- data[!excluded_id %in% data[[id]], ]
+    }
   }
 
   ## Calculate central tendencies ----------------------------------------------

--- a/R/apa_factorial_plot.R
+++ b/R/apa_factorial_plot.R
@@ -300,7 +300,7 @@ apa_factorial_plot.default <- function(
     removed_cases <- unlist(attributes(aggregated)[c("removed_cases_implicit_NA", "removed_cases_explicit_NA")])
     if(!is.null(removed_cases)) {
       excluded_id <- sort(unique(removed_cases))
-      data <- data[!excluded_id %in% data[[id]], ]
+      data <- data[!data[[id]] %in% excluded_id, ]
     }
   }
 

--- a/R/apa_lineplot.R
+++ b/R/apa_lineplot.R
@@ -59,7 +59,6 @@ apa_lineplot.default <- function(
   , fun_aggregate = mean
   , na.rm = TRUE
   , use = "all.obs"
-  , reference = 0
   , intercept = NULL
   , args_x_axis = NULL
   , args_y_axis = NULL

--- a/R/apa_lineplot.R
+++ b/R/apa_lineplot.R
@@ -58,6 +58,7 @@ apa_lineplot.default <- function(
   , level = 0.95
   , fun_aggregate = mean
   , na.rm = TRUE
+  , use = "all.obs"
   , reference = 0
   , intercept = NULL
   , args_x_axis = NULL
@@ -85,6 +86,7 @@ apa_lineplot.default <- function(
       , level = level
       , fun_aggregate = substitute(fun_aggregate)
       , na.rm = na.rm
+      , use = use
       , intercept = intercept
       , args_x_axis = args_x_axis
       , args_y_axis = args_y_axis

--- a/R/calculations.R
+++ b/R/calculations.R
@@ -117,7 +117,24 @@ wsci <- function(data, id, factors, dv, level = .95, method = "Morey") {
     stop("More than one observation per cell. Ensure you aggregated multiple observations per participant/within-subjects condition combination.")
   }
 
-  # split by between factors
+  # ----------------------------------------------------------------------------
+  # Handling of missing values
+
+  if(anyNA(data[[dv]])) {
+    excluded_id <- sort(unique(data[[id]][is.na(data[[dv]])]))
+
+    data <- data[!data[[id]]%in%excluded_id, ]
+
+    warning(
+      "Because of missing values, the following cases were removed from calculation of within-subjects confidence intervals:\n"
+      , id
+      , ": "
+      , paste(excluded_id, collapse = ", ")
+    )
+  }
+
+
+  # split by between-subjects factors
   if (is.null(between)) {
     splitted <- list(data)
   } else if(length(between)>1){

--- a/R/calculations.R
+++ b/R/calculations.R
@@ -127,7 +127,7 @@ wsci <- function(data, id, factors, dv, level = .95, method = "Morey") {
   # print warnings ----
   if("removed_cases_explicit_NA" %in% names(attributes(data))) {
     warning(
-      "Because of missing values, the following cases were removed from calculation of within-subjects confidence intervals:\n"
+      "Because of NAs in the dependent variable, the following cases were removed from calculation of within-subjects confidence intervals:\n"
       , id
       , ": "
       , paste(attr(data, "removed_cases_explicit_NA"), collapse = ", ")

--- a/R/printnum.R
+++ b/R/printnum.R
@@ -39,7 +39,11 @@ printnum <- function(x, ...) {
 printnum.default <- function(x, na_string = getOption("papaja.na_string"), ...) {
   if(is.null(x)) stop("The parameter 'x' is NULL. Please provide a value for 'x'")
 
-  as.character(x)
+  x <- as.character(x)
+  if(anyNA(x)) {
+    x[is.na(x)] <- na_string
+  }
+  x
 }
 
 

--- a/R/printnum.R
+++ b/R/printnum.R
@@ -38,13 +38,8 @@ printnum <- function(x, ...) {
 
 printnum.default <- function(x, na_string = getOption("papaja.na_string"), ...) {
   if(is.null(x)) stop("The parameter 'x' is NULL. Please provide a value for 'x'")
-  if(anyNA(x)){
-    rep(na_string, length(x))
-  } else {
-    as.character(x)
-  }
-  # Don't use printnum.numeric as a default if it only allows numeric input:
-  # printnum.numeric(x, ...)
+
+  as.character(x)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -531,7 +531,7 @@ complete_observations <- function(data, id, within, dv) {
     data <- data[!(data[[id]] %in% excluded_id), ]
     data[[id]] <- droplevels(data[[id]])
 
-    explicit_NA <- excluded_id
+    explicit_NA <- as.character(excluded_id)
   }
 
   # implicit NAs

--- a/R/utils.R
+++ b/R/utils.R
@@ -501,7 +501,23 @@ determine_within_between <- function(data, id, factors) {
   )
 }
 
-
+#' Remove Incomplete Observations from Data Frame
+#'
+#' This is an internal function that is used to remove incomplete observations
+#' from a \code{data.frame}. It removes (1) explicit NAs and (2) cases with
+#' implicit NAs, i.e. participants who did not provide observations for all
+#' combinations of (possibly multiple) within-subjects factors.
+#'
+#' @param data The \code{data.frame} to be processed.
+#' @param id Character. Name of the column containing the subject identifier.
+#' @param within Character. Names of the columns containing within-subjects factors.
+#' @param dv Character. Name of the column containing the dependent variable.
+#' @return
+#'   A \code{data.frame} where NAs and incomplete observations are removed.
+#'   It also has up to two additional attributes \code{removed_cases_explicit_NA}
+#'   and \code{removed_cases_implicit_NA}, carrying the subject identifiers of
+#'   participants whose data has been removed.
+#'
 #' @keywords internal
 
 complete_observations <- function(data, id, within, dv) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -471,3 +471,33 @@ rename_column <- function(x, current_name, new_name) {
   x
 }
 
+
+#' @keywords internal
+
+determine_within_between <- function(data, id, factors) {
+
+  data <- droplevels(data)
+
+  number_of_levels <- function(x) {
+    length(unique(x))
+  }
+
+  within <- c()
+  between <- c()
+
+  for (i in factors) {
+    n_levels <- aggregate(x = data[[i]], by = list(data[[id]]), FUN = number_of_levels)
+    if(any(n_levels$x>1)) {
+      within <- c(within, i)
+    } else {
+      between <- c(between, i)
+    }
+  }
+
+  # return
+  list(
+    "within" = within
+    , "between" =  between
+  )
+}
+

--- a/R/variable_label.R
+++ b/R/variable_label.R
@@ -160,7 +160,8 @@ default_label.default <- function(x, ...) no_method(x)
 #' @keywords internal
 
 default_label.data.frame <- function(x) {
-  as.data.frame.list(
+
+  x_out <- as.data.frame.list(
     x = mapply(
       FUN = function(y, value) {
         if(is.null(variable_label(y))) {
@@ -175,7 +176,11 @@ default_label.data.frame <- function(x) {
     )
     , check.names = FALSE
     , stringsAsFactors = FALSE
+    , col.names = attr(x, "names")
+    , row.names = attr(x, "row.names") # `rownames(x)` would coerce to character
   )
+  attributes(x_out) <- attributes(x)
+  x_out
 }
 
 # setMethod(

--- a/man/apa_barplot.Rd
+++ b/man/apa_barplot.Rd
@@ -48,7 +48,7 @@ before calculating descriptive statistics for each cell of the design. Defaults 
 \item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
 Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
 
-\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.}
+\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to \code{0}.}
 
 \item{intercept}{Numeric. Adds a horizontal line at height \code{intercept} to the plot. Can be either a single value or a matrix. For the matrix
 case, multiple lines are drawn, where the dimensions of the matrix determine the number of lines to be drawn.}

--- a/man/apa_barplot.Rd
+++ b/man/apa_barplot.Rd
@@ -10,10 +10,10 @@ apa_barplot(data, ...)
 
 \method{apa_barplot}{default}(data, id, factors = NULL, dv, tendency = mean,
   dispersion = conf_int, level = 0.95, fun_aggregate = mean,
-  na.rm = TRUE, reference = 0, intercept = NULL, args_x_axis = NULL,
-  args_y_axis = NULL, args_title = NULL, args_rect = NULL,
-  args_error_bars = NULL, args_legend = NULL, xlab = NULL, ylab = NULL,
-  main = NULL, ...)
+  na.rm = TRUE, use = "all.obs", reference = 0, intercept = NULL,
+  args_x_axis = NULL, args_y_axis = NULL, args_title = NULL,
+  args_rect = NULL, args_error_bars = NULL, args_legend = NULL,
+  xlab = NULL, ylab = NULL, main = NULL, ...)
 
 \method{apa_barplot}{afex_aov}(data, tendency = mean, dispersion = conf_int,
   fun_aggregate = mean, ...)
@@ -44,6 +44,9 @@ for 95\% confidence intervals. Ignored if \code{dispersion} is not a confidence-
 before calculating descriptive statistics for each cell of the design. Defaults to \code{mean}.}
 
 \item{na.rm}{Logical. Specifies if missing values are removed. Defaults to \code{TRUE}.}
+
+\item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
+Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
 
 \item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.}
 

--- a/man/apa_beeplot.Rd
+++ b/man/apa_beeplot.Rd
@@ -10,10 +10,11 @@ apa_beeplot(data, ...)
 
 \method{apa_beeplot}{default}(data, id, factors = NULL, dv, tendency = mean,
   dispersion = conf_int, level = 0.95, fun_aggregate = mean,
-  na.rm = TRUE, reference = 0, intercept = NULL, args_x_axis = NULL,
-  args_y_axis = NULL, args_title = NULL, args_points = NULL,
-  args_swarm = NULL, args_error_bars = NULL, args_legend = NULL,
-  jit = 0.3, xlab = NULL, ylab = NULL, main = NULL, ...)
+  na.rm = TRUE, use = "all.obs", reference = 0, intercept = NULL,
+  args_x_axis = NULL, args_y_axis = NULL, args_title = NULL,
+  args_points = NULL, args_swarm = NULL, args_error_bars = NULL,
+  args_legend = NULL, jit = 0.3, xlab = NULL, ylab = NULL,
+  main = NULL, ...)
 
 \method{apa_beeplot}{afex_aov}(data, tendency = mean, dispersion = conf_int,
   fun_aggregate = mean, ...)
@@ -44,6 +45,9 @@ for 95\% confidence intervals. Ignored if \code{dispersion} is not a confidence-
 before calculating descriptive statistics for each cell of the design. Defaults to \code{mean}.}
 
 \item{na.rm}{Logical. Specifies if missing values are removed. Defaults to \code{TRUE}.}
+
+\item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
+Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
 
 \item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.}
 

--- a/man/apa_beeplot.Rd
+++ b/man/apa_beeplot.Rd
@@ -49,7 +49,7 @@ before calculating descriptive statistics for each cell of the design. Defaults 
 \item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
 Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
 
-\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.}
+\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to \code{0}.}
 
 \item{intercept}{Numeric. Adds a horizontal line at height \code{intercept} to the plot. Can be either a single value or a matrix. For the matrix
 case, multiple lines are drawn, where the dimensions of the matrix determine the number of lines to be drawn.}

--- a/man/apa_beeplot.Rd
+++ b/man/apa_beeplot.Rd
@@ -10,11 +10,10 @@ apa_beeplot(data, ...)
 
 \method{apa_beeplot}{default}(data, id, factors = NULL, dv, tendency = mean,
   dispersion = conf_int, level = 0.95, fun_aggregate = mean,
-  na.rm = TRUE, use = "all.obs", reference = 0, intercept = NULL,
-  args_x_axis = NULL, args_y_axis = NULL, args_title = NULL,
-  args_points = NULL, args_swarm = NULL, args_error_bars = NULL,
-  args_legend = NULL, jit = 0.3, xlab = NULL, ylab = NULL,
-  main = NULL, ...)
+  na.rm = TRUE, use = "all.obs", intercept = NULL, args_x_axis = NULL,
+  args_y_axis = NULL, args_title = NULL, args_points = NULL,
+  args_swarm = NULL, args_error_bars = NULL, args_legend = NULL,
+  jit = 0.3, xlab = NULL, ylab = NULL, main = NULL, ...)
 
 \method{apa_beeplot}{afex_aov}(data, tendency = mean, dispersion = conf_int,
   fun_aggregate = mean, ...)
@@ -48,8 +47,6 @@ before calculating descriptive statistics for each cell of the design. Defaults 
 
 \item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
 Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
-
-\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to \code{0}.}
 
 \item{intercept}{Numeric. Adds a horizontal line at height \code{intercept} to the plot. Can be either a single value or a matrix. For the matrix
 case, multiple lines are drawn, where the dimensions of the matrix determine the number of lines to be drawn.}

--- a/man/apa_factorial_plot.Rd
+++ b/man/apa_factorial_plot.Rd
@@ -56,7 +56,7 @@ before calculating descriptive statistics for each cell of the design. Defaults 
 \item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
 Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
 
-\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.}
+\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to \code{0}.}
 
 \item{intercept}{Numeric. Adds a horizontal line at height \code{intercept} to the plot. Can be either a single value or a matrix. For the matrix
 case, multiple lines are drawn, where the dimensions of the matrix determine the number of lines to be drawn.}

--- a/man/apa_factorial_plot.Rd
+++ b/man/apa_factorial_plot.Rd
@@ -10,11 +10,12 @@ apa_factorial_plot(data, ...)
 
 \method{apa_factorial_plot}{default}(data, id, factors = NULL, dv,
   tendency = mean, dispersion = conf_int, level = 0.95,
-  fun_aggregate = mean, na.rm = TRUE, reference = 0, intercept = NULL,
-  args_x_axis = NULL, args_y_axis = NULL, args_title = NULL,
-  args_rect = NULL, args_points = NULL, args_lines = NULL,
-  args_swarm = NULL, args_error_bars = NULL, args_legend = NULL,
-  plot = NULL, jit = 0.3, xlab = NULL, ylab = NULL, main = NULL, ...)
+  fun_aggregate = mean, na.rm = TRUE, use = "all.obs", reference = 0,
+  intercept = NULL, args_x_axis = NULL, args_y_axis = NULL,
+  args_title = NULL, args_rect = NULL, args_points = NULL,
+  args_lines = NULL, args_swarm = NULL, args_error_bars = NULL,
+  args_legend = NULL, plot = NULL, jit = 0.3, xlab = NULL,
+  ylab = NULL, main = NULL, ...)
 
 \method{apa_factorial_plot}{afex_aov}(data, tendency = mean,
   dispersion = conf_int, fun_aggregate = mean, ...)
@@ -51,6 +52,9 @@ for 95\% confidence intervals. Ignored if \code{dispersion} is not a confidence-
 before calculating descriptive statistics for each cell of the design. Defaults to \code{mean}.}
 
 \item{na.rm}{Logical. Specifies if missing values are removed. Defaults to \code{TRUE}.}
+
+\item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
+Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
 
 \item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.}
 

--- a/man/apa_lineplot.Rd
+++ b/man/apa_lineplot.Rd
@@ -10,11 +10,11 @@ apa_lineplot(data, ...)
 
 \method{apa_lineplot}{default}(data, id, factors = NULL, dv,
   tendency = mean, dispersion = conf_int, level = 0.95,
-  fun_aggregate = mean, na.rm = TRUE, use = "all.obs", reference = 0,
-  intercept = NULL, args_x_axis = NULL, args_y_axis = NULL,
-  args_title = NULL, args_points = NULL, args_lines = NULL,
-  args_error_bars = NULL, args_legend = NULL, jit = 0.3, xlab = NULL,
-  ylab = NULL, main = NULL, ...)
+  fun_aggregate = mean, na.rm = TRUE, use = "all.obs", intercept = NULL,
+  args_x_axis = NULL, args_y_axis = NULL, args_title = NULL,
+  args_points = NULL, args_lines = NULL, args_error_bars = NULL,
+  args_legend = NULL, jit = 0.3, xlab = NULL, ylab = NULL,
+  main = NULL, ...)
 
 \method{apa_lineplot}{afex_aov}(data, tendency = mean,
   dispersion = conf_int, fun_aggregate = mean, ...)
@@ -48,8 +48,6 @@ before calculating descriptive statistics for each cell of the design. Defaults 
 
 \item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
 Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
-
-\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to \code{0}.}
 
 \item{intercept}{Numeric. Adds a horizontal line at height \code{intercept} to the plot. Can be either a single value or a matrix. For the matrix
 case, multiple lines are drawn, where the dimensions of the matrix determine the number of lines to be drawn.}

--- a/man/apa_lineplot.Rd
+++ b/man/apa_lineplot.Rd
@@ -10,11 +10,11 @@ apa_lineplot(data, ...)
 
 \method{apa_lineplot}{default}(data, id, factors = NULL, dv,
   tendency = mean, dispersion = conf_int, level = 0.95,
-  fun_aggregate = mean, na.rm = TRUE, reference = 0, intercept = NULL,
-  args_x_axis = NULL, args_y_axis = NULL, args_title = NULL,
-  args_points = NULL, args_lines = NULL, args_error_bars = NULL,
-  args_legend = NULL, jit = 0.3, xlab = NULL, ylab = NULL,
-  main = NULL, ...)
+  fun_aggregate = mean, na.rm = TRUE, use = "all.obs", reference = 0,
+  intercept = NULL, args_x_axis = NULL, args_y_axis = NULL,
+  args_title = NULL, args_points = NULL, args_lines = NULL,
+  args_error_bars = NULL, args_legend = NULL, jit = 0.3, xlab = NULL,
+  ylab = NULL, main = NULL, ...)
 
 \method{apa_lineplot}{afex_aov}(data, tendency = mean,
   dispersion = conf_int, fun_aggregate = mean, ...)
@@ -45,6 +45,9 @@ for 95\% confidence intervals. Ignored if \code{dispersion} is not a confidence-
 before calculating descriptive statistics for each cell of the design. Defaults to \code{mean}.}
 
 \item{na.rm}{Logical. Specifies if missing values are removed. Defaults to \code{TRUE}.}
+
+\item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
+Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
 
 \item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.}
 

--- a/man/apa_lineplot.Rd
+++ b/man/apa_lineplot.Rd
@@ -49,7 +49,7 @@ before calculating descriptive statistics for each cell of the design. Defaults 
 \item{use}{Character. Specifies a method to exclude cases if there are missing values \emph{after} aggregating.
 Possible options are \code{"all.obs"} or \code{"complete.obs"}.}
 
-\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to\code{0}.}
+\item{reference}{Numeric. A reference point that determines the \emph{y} coordinate of the \emph{x} axis. Useful if there exists a 'nil' value; defaults to \code{0}.}
 
 \item{intercept}{Numeric. Adds a horizontal line at height \code{intercept} to the plot. Can be either a single value or a matrix. For the matrix
 case, multiple lines are drawn, where the dimensions of the matrix determine the number of lines to be drawn.}

--- a/tests/testthat/test_apa_factorial_plot.R
+++ b/tests/testthat/test_apa_factorial_plot.R
@@ -181,4 +181,31 @@ test_that(
   }
 )
 
+test_that(
+  'apa_factorial_plot.default(): use = "complete.obs"'
+  , {
+    object_1 <- apa_factorial_plot(
+      data = npk[2:24, ]
+      , id = "block"
+      , dv = "yield"
+      , factors = c("N", "P")
+      , dispersion = wsci
+      , use = "complete.obs"
+      , plot = c("lines", "points", "error_bars", "swarms", "bars")
+    )
+
+    expect_equal(
+      object = attributes(object_1$data)$removed_cases_implicit_NA
+      , expected = "1"
+    )
+
+    reference_object <- default_label(droplevels(npk[5:24, c("block", "N", "P", "yield")]))
+    attr(reference_object, "removed_cases_implicit_NA") <- "1"
+    expect_equal(
+      object = object_1$data
+      , expected = reference_object
+    )
+  }
+)
+
 file.remove("Rplots.pdf")

--- a/tests/testthat/test_calculations.R
+++ b/tests/testthat/test_calculations.R
@@ -244,6 +244,28 @@ test_that(
   }
 )
 
+test_that(
+  "Within-subjects confidence intervals: Handling of implicit and explicit NAs"
+  , {
+    # Implicit NAs
+    data <- npk
+    data$yield[2] <- NA
+    aggregated <- aggregate(formula = yield ~ N + P + block, data = data, FUN = mean)
+    expect_warning(
+      wsci(data = aggregated, id = "block", dv = "yield", factors = c("N", "P"))
+      , "Because of incomplete data, the following cases were removed from calculation of within-subjects confidence intervals:\nblock: 1"
+    )
+    # Explicit NAs
+    data <- npk
+    aggregated <- aggregate(formula = yield ~ N + P + block, data = data, FUN = mean)
+    aggregated$yield[5] <- NA
+    expect_warning(
+      wsci(data = aggregated, id = "block", dv = "yield", factors = c("N", "P"))
+      , "Because of missing values, the following cases were removed from calculation of within-subjects confidence intervals:\nblock: 2"
+    )
+  }
+)
+
 
 test_that(
   "Within-subjects confidence intervals: Throw error if data are not properly aggregated."

--- a/tests/testthat/test_calculations.R
+++ b/tests/testthat/test_calculations.R
@@ -261,7 +261,7 @@ test_that(
     aggregated$yield[5] <- NA
     expect_warning(
       wsci(data = aggregated, id = "block", dv = "yield", factors = c("N", "P"))
-      , "Because of missing values, the following cases were removed from calculation of within-subjects confidence intervals:\nblock: 2"
+      , "Because of NAs in the dependent variable, the following cases were removed from calculation of within-subjects confidence intervals:\nblock: 2"
     )
   }
 )

--- a/tests/testthat/test_printnum.R
+++ b/tests/testthat/test_printnum.R
@@ -21,8 +21,8 @@ test_that(
 
     expect_equal(printnum(-0.0001), "0.00")
 
-    expect_equal(printnum(NA), "NA")
-    expect_equal(printnum(NA, na_string = "-"), "-")
+    expect_equal(printnum(c(NA, "a")), c("NA", "a"))
+    expect_equal(printnum(c(NA, "b"), na_string = "-"), c("-", "b"))
   }
 )
 

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -66,7 +66,7 @@ test_that(
 
     data <- npk[2:16, ]
     test <- determine_within_between(data = data, id = "block", factors = c("N", "P", "K"))
-    expect_equal(test, list(within = c("N", "P", "K"), between = NULL))
+    expect_identical(test, list(within = c("N", "P", "K"), between = NULL))
   }
 )
 
@@ -112,7 +112,7 @@ test_that(
         , .Names = c("block", "N", "P", "K", "yield")
         , row.names = c(1L, 2L, 3L, 4L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L)
         , class = "data.frame"
-        , removed_cases_explicit_NA = structure(2L, .Label = c("1", "2", "3", "4", "5", "6"), class = "factor")
+        , removed_cases_explicit_NA = c("2")
       )
     )
   }

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -69,3 +69,51 @@ test_that(
     expect_equal(test, list(within = c("N", "P", "K"), between = NULL))
   }
 )
+
+test_that(
+  "complete_observations"
+  , {
+    test <- complete_observations(data = npk, id = "block", dv = "yield", within = c("N", "P"))
+
+    expect_identical(
+      object = test
+      , expected = npk
+    )
+
+    data <- npk
+    data$yield[5] <- NA
+    test <- papaja:::complete_observations(data = data, id = "block", dv = "yield", within = c("N", "K"))
+
+    expect_identical(
+      object = test
+      , expected = structure(
+        list(
+          block = structure(
+            c(1L, 1L, 1L, 1L, 2L, 2L, 2L, 2L, 3L, 3L, 3L, 3L, 4L, 4L, 4L, 4L, 5L, 5L, 5L, 5L)
+            , .Label = c("1", "3", "4", "5", "6")
+            , class = "factor"
+          )
+          , N = structure(
+            c(1L, 2L, 1L, 2L, 1L, 2L, 2L, 1L, 2L, 2L, 1L, 1L, 2L, 1L, 2L, 1L, 2L, 2L, 1L, 1L)
+            , .Label = c("0", "1"), class = "factor"
+          )
+          , P = structure(
+            c(2L, 2L, 1L, 1L, 2L, 2L, 1L, 1L, 1L, 2L, 1L, 2L, 2L, 1L, 1L, 2L, 1L, 2L, 2L, 1L)
+            , .Label = c("0", "1")
+            , class = "factor"
+          )
+          , K = structure(
+            c(2L, 1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 2L, 1L, 1L, 1L, 2L, 2L, 2L, 1L, 2L, 1L)
+            , .Label = c("0", "1")
+            , class = "factor"
+          )
+          , yield = c(49.5, 62.8, 46.8, 57, 62.8, 55.8, 69.5, 55, 62, 48.8, 45.5, 44.2, 52, 51.5, 49.8, 48.8, 57.2, 59, 53.2, 56)
+        )
+        , .Names = c("block", "N", "P", "K", "yield")
+        , row.names = c(1L, 2L, 3L, 4L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L)
+        , class = "data.frame"
+        , removed_cases_explicit_NA = structure(2L, .Label = c("1", "2", "3", "4", "5", "6"), class = "factor")
+      )
+    )
+  }
+)

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -57,3 +57,15 @@ test_that(
     expect_equal(in_paren("$F(1, 234) = 1$"), "$F[1, 234] = 1$")
   }
 )
+
+test_that(
+  "determine_within_between"
+  , {
+    test <- determine_within_between(data = npk, id = "block", factors = c("N", "P", "K"))
+    expect_equal(test, list(within = c("N", "P", "K"), between = NULL))
+
+    data <- npk[2:16, ]
+    test <- determine_within_between(data = data, id = "block", factors = c("N", "P", "K"))
+    expect_equal(test, list(within = c("N", "P", "K"), between = NULL))
+  }
+)


### PR DESCRIPTION
NAs are now handled explicitly in plot functions and `wsci`(which calculates within-subjects confidence intervals).

- When calculating within-Ss CIs, cases with NAs are removed list-wise (i.e., all observations from this participant are removed), and a warning is issued, it lists the values of the subject identifier of excluded participants.
- Plot functions now have an additional parameter `use`, which allows to include either all non-missing observations (`use = "all.obs"`) or only complete observations (`use = "complete.obs"`) - which, again, implies list-wise removal of participants who provided incomplete data.