### PR TITLE
Update skeleton.Rmd

### DIFF
--- a/inst/rmarkdown/templates/apa6/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/apa6/skeleton/skeleton.Rmd
@@ -59,7 +59,7 @@ output            : papaja::apa6_pdf
 
 ```{r setup, include = FALSE}
 library("papaja")
-papaja::r_refs("r-references.bib")
+r_refs("r-references.bib")
 
 ```
 
@@ -92,9 +92,6 @@ We used `r cite_r("r-references.bib")` for all our analyses.
 \newpage
 
 # References
-```{r create_r-references}
-r_refs(file = "r-references.bib")
-```
 
 \begingroup
 \setlength{\parindent}{-0.5in}

--- a/inst/rmarkdown/templates/apa6/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/apa6/skeleton/skeleton.Rmd
@@ -59,6 +59,8 @@ output            : papaja::apa6_pdf
 
 ```{r setup, include = FALSE}
 library("papaja")
+papaja::r_refs("r-references.bib")
+
 ```
 
 ```{r analysis-preferences}


### PR DESCRIPTION
Added `papaja::r_refs('r-references.bib')` to the first code chunk. Idea here is that when I try to compile this from scratch, the first time, it warns me that r-references.bib is missing, and if you're using a container to execute this as a one-off (e.g. Code Ocean), it'll be a problem each time. So the point is to create the file before it is called in line 84.