### PR TITLE
fixed multiple formats in modify_input_file

### DIFF
--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -76,7 +76,7 @@ apa6_pdf <- function(
   config$knitr$opts_chunk$dpi <- 300
   config$clean_supporting <- FALSE # Always keep images files
 
-  config$pre_knit <- modify_input_file
+  config$pre_knit <- function(input, ...) { modify_input_file(input=input, format="papaja::apa6_pdf") }
 
   ## Overwrite preprocessor to set CSL defaults
   saved_files_dir <- NULL
@@ -237,7 +237,7 @@ apa6_docx <- function(
   config$knitr$opts_chunk$dpi <- 300
   config$clean_supporting <- FALSE # Always keep images files
 
-  config$pre_knit <- modify_input_file
+  config$pre_knit <- function(input, ...) { modify_input_file(input=input, format="papaja::apa6_docx") }
 
   ## Overwrite preprocessor to set CSL defaults
   saved_files_dir <- NULL
@@ -826,7 +826,7 @@ set_ampersand_filter <- function(args, csl_file) {
 }
 
 
-modify_input_file <- function(input, ...) {
+modify_input_file <- function(input, format) {
   input_connection <- file(input, encoding = "UTF-8")
   on.exit(close.connection(input_connection))
   input_text <- readLines(con = input_connection)
@@ -839,8 +839,6 @@ modify_input_file <- function(input, ...) {
     if(!file.copy(input, file.path(dirname(input), hashed_name))) {
       stop(paste0("Could not create a copy of the original input file '", input, "' while trying to render the appendix."))
     } else {
-      format <- if(is.character(yaml_params$output)) yaml_params$output else names(yaml_params$output)
-
       # Add render_appendix()-chunk
       for(i in seq_along(yaml_params$appendix)) {
         input_text <- c(
@@ -854,7 +852,7 @@ modify_input_file <- function(input, ...) {
           } else NULL
           , ""
           , "```{r echo = FALSE, results = 'asis', cache = FALSE}"
-          , paste0("render_appendix('", yaml_params$appendix[i], "')")
+          , paste0("papaja::render_appendix('", yaml_params$appendix[i], "')")
           , "```"
           , ""
         )


### PR DESCRIPTION
Hello,

Thanks for the awesome `papaja` package!

However, since the knitting of markdown appendixes is possible I had a problem with multiple output documents. Here is a MWE.

main.Rmd:
```
---
title             : "The title"
shorttitle        : "Title"

author: 
  - name          : "First Author"
    affiliation   : "1"
    corresponding : yes    # Define only one corresponding author
    address       : "Postal address"
    email         : "my@email.com"
  - name          : "Ernst-August Doelle"
    affiliation   : "1,2"

affiliation:
  - id            : "1"
    institution   : "Wilhelm-Wundt-University"
  - id            : "2"
    institution   : "Konstanz Business School"
  
keywords          : "keywords"
wordcount         : "X"
appendix          : "appendix.Rmd"

bibliography      : ["r-references.bib"]

floatsintext      : no
figurelist        : no
tablelist         : no
footnotelist      : no
linenumbers       : yes
mask              : no
draft             : no

documentclass     : "apa6"
classoption       : "man"
output            : 
    papaja::apa6_word:
        default
    papaja::apa6_pdf:
        default
---


# Methods

## Participants

## Material

## Procedure

## Data analysis

# Results

# Discussion
```

appendix.Rmd:
```
# Measures

Test
```

If I want to compile this, I get the following warning:
```
Error in render_appendix("appendix.Rmd") : 
  could not find function "render_appendix"
In addition: Warning message:
In if (format %in% c("papaja::apa6_word", "papaja::apa6_docx")) { :
  the condition has length > 1 and only the first element will be used
```

The first occurs only if I haven't loaded the papaja package. The second occurs always. This pull request fixes this issue.

Best,
mutlusun