### PR TITLE
Include cslreferences class in revision_letter template

### DIFF
--- a/inst/rmarkdown/templates/revision_letter/resources/revision_letter.tex
+++ b/inst/rmarkdown/templates/revision_letter/resources/revision_letter.tex
@@ -137,6 +137,16 @@ $for(header-includes)$
   $header-includes$
 $endfor$
 
+
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newenvironment{cslreferences}%
+  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
+  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
+  {\par}
+$endif$
+
 \begin{document}
 
 {\Large\bf Author response to reviews of}\\[1em]


### PR DESCRIPTION
This change includes the cslreferences change implemented in pandoc 2.8. 