### PR TITLE
Prevent indented first reference papaja::revision_letter_pdf

### DIFF
--- a/inst/rmarkdown/templates/revision_letter/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/revision_letter/skeleton/skeleton.Rmd
@@ -56,6 +56,9 @@ This is our response
 
 # References
 
+\noindent
+\vspace{-0.5cm}
+
 \begingroup
 \setlength{\parindent}{-0.5in}
 \setlength{\leftskip}{0.5in}


### PR DESCRIPTION
Simple fix to prevent the first reference in the revision letter being indented #296.