### PR TITLE
set default csl arguments for revision letter

### DIFF
--- a/R/revision_letter_format.R
+++ b/R/revision_letter_format.R
@@ -74,7 +74,9 @@ revision_letter_preprocessor <- function(metadata, input_file, runtime, knit_met
      (is.null(metadata$citeproc) || metadata$citeproc)) {
 
     ## Set CSL
-    args <- set_default_csl(input_file)
+    args <- set_default_csl(input_file
+                            , version = 6
+                            , metadata = metadata)
     csl_specified <- is.null(args)
 
     ## Set ampersand filter


### PR DESCRIPTION
The revision letter currently cannot be knitted due to changes to set_default_csl.
This request sets those arguments to restore functionality.