### PR TITLE
apa6_formats: correctly check against class(x)

### DIFF
--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -304,7 +304,7 @@ apa6_word <- apa6_docx
 # Set hook to print default numbers
 inline_numbers <- function (x) {
 
-  if(class(x) %in% c("difftime")) x <- as.numeric(x)
+  if("difftime" %in% class(x)) x <- as.numeric(x)
   if(is.numeric(x)) {
     printed_number <- ifelse(
       x == round(x)

--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -304,7 +304,7 @@ apa6_word <- apa6_docx
 # Set hook to print default numbers
 inline_numbers <- function (x) {
 
-  if("difftime" %in% class(x)) x <- as.numeric(x)
+  if(inherits(x, "difftime")) x <- as.numeric(x)
   if(is.numeric(x)) {
     printed_number <- ifelse(
       x == round(x)


### PR DESCRIPTION
Hello,

I ran into a small issue if certain numbers have more than one class. Following warning occurs:

```
1: In if (class(x) %in% c("difftime")) x <- as.numeric(x) :
  the condition has length > 1 and only the first element will be used
```

This PR correctly checks against the class function and the warning is no longer thrown. However, this might alter the default behavior if a user printed a R object that is a number and a difftime (I'm not sure whether this case exists).

Best