### PR TITLE
Correctly clean temporary file if appendix is used

### DIFF
--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -714,7 +714,9 @@ revert_original_input_file <- function(x = 1) {
   input_file <- get("original_input", envir = parent.frame(x))
   input_file <- tools::file_path_as_absolute(input_file)
 
-  if(!is.null(rmarkdown::metadata$appendix)) {
+  yaml_params <- get_yaml_params(readLines(input_file))
+
+  if(!is.null(yaml_params$appendix)) {
     hashed_name <- paste0(base64enc::base64encode(charToRaw(basename(input_file))), ".Rmd")
 
     if(!file.copy(file.path(dirname(input_file), hashed_name), input_file, overwrite = TRUE)) {

--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -714,9 +714,7 @@ revert_original_input_file <- function(x = 1) {
   input_file <- get("original_input", envir = parent.frame(x))
   input_file <- tools::file_path_as_absolute(input_file)
 
-  yaml_params <- get_yaml_params(readLines(input_file))
-
-  if(!is.null(yaml_params$appendix)) {
+  if(!is.null(rmarkdown::metadata$appendix)) {
     hashed_name <- paste0(base64enc::base64encode(charToRaw(basename(input_file))), ".Rmd")
 
     if(!file.copy(file.path(dirname(input_file), hashed_name), input_file, overwrite = TRUE)) {

--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -714,13 +714,15 @@ revert_original_input_file <- function(x = 1) {
   input_file <- get("original_input", envir = parent.frame(x))
   input_file <- tools::file_path_as_absolute(input_file)
 
-  if(!is.null(rmarkdown::metadata$appendix)) {
-    hashed_name <- paste0(base64enc::base64encode(charToRaw(basename(input_file))), ".Rmd")
+  hashed_name <- paste0(base64enc::base64encode(charToRaw(basename(input_file))), ".Rmd")
+  hashed_path <- file.path(dirname(input_file), hashed_name)
 
-    if(!file.copy(file.path(dirname(input_file), hashed_name), input_file, overwrite = TRUE)) {
-      stop(paste0("Could not revert modified input file to original input file after trying to render the appendix. The file '", dirname(input_file), "' has been modified. A copy of the orignal input file named '", hashed_name, "' has been saved in the same directory."))
+  if(file.exists(hashed_path)) {
+
+    if(!file.copy(hashed_path, input_file, overwrite = TRUE)) {
+      stop(paste0("Could not revert modified input file to original input file after trying to render the appendix. The file '", basename(input_file), "' has been modified. A copy of the orignal input file named '", hashed_name, "' has been saved in the same directory."))
     } else {
-      unlink(file.path(dirname(input_file), hashed_name))
+      unlink(hashed_path)
     }
   }
 


### PR DESCRIPTION
Hello,

having `appendix: "appendix.Rmd"` in my YAML-Header, the temporary input file was not cleaned up. This resulted in the following error on the following run (cf. #322 ):

```
Error in modify_input_file(input = input, format = "papaja::apa6_docx") : 
  Could not create a copy of the original input file 'XXX/main.Rmd' while trying to render the appendix.
```

The temporary input file was not cleaned up, because `rmarkdown::metadata$appendix` is not available on exit. Thus, the YAML header has to be reread on exit.