### PR TITLE
Report correct denominator df for comparisons of linear models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,6 @@ SystemRequirements: Rendering the document template requires pandoc (>= 2.0; htt
 License: MIT + file LICENSE
 LazyData: yes
 Encoding: UTF-8
-RoxygenNote: 7.1.0.9000
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Language: en-US

--- a/R/arrange_anova.R
+++ b/R/arrange_anova.R
@@ -56,7 +56,7 @@ arrange_anova.anova <- function(x) {
     x[, c("sumsq", "df", "statistic", "p.value")] <- object[!resid_row, c("Sum of Sq", "Df", "F", "Pr(>F)")]
     x$df <- abs(x$df) # Objects give difference in Df
     x$sumsq_err <- object[!resid_row, "RSS"]
-    x$df_res <- object[resid_row, "Res.Df"]
+    x$df_res <- pmin(object[resid_row, "Res.Df"], object[!resid_row, "Res.Df"])
     x$term <- paste0("model", 2:nrow(object))
 
     class(x) <- c("apa_model_comp", class(x))

--- a/tests/testthat/test_apa_print_model_comp.R
+++ b/tests/testthat/test_apa_print_model_comp.R
@@ -20,8 +20,8 @@ test_that(
     expect_is(model_comp$stat$Length, "character")
     expect_is(model_comp$stat$Both, "character")
 
-    expect_equal(model_comp$stat$Length, "$F(1, 148) = 853.31$, $p < .001$")
-    expect_equal(model_comp$stat$Both, "$F(1, 148) = 19.04$, $p < .001$")
+    expect_equal(model_comp$stat$Length, "$F(1, 147) = 853.31$, $p < .001$")
+    expect_equal(model_comp$stat$Both, "$F(1, 146) = 19.04$, $p < .001$")
 
     # est
     expect_is(model_comp$est, "list")
@@ -45,8 +45,8 @@ test_that(
     correct_table <- structure(
       list(
         Baseline = c("$6.53$ $[5.58$, $7.47]$", "$-0.22$ $[-0.53$, $0.08]$", "", "", "$.01$ $[0.00$, $0.06]$", "2.07", "1", "148", ".152", "371.99", "381.02", "", "", "", "", "", "", "")
-        , Length = c("$2.25$ $[1.76$, $2.74]$", "$0.60$ $[0.46$, $0.73]$", "$0.47$ $[0.44$, $0.51]$", "", "$.84$ $[0.79$, $0.87]$", "386.39", "2", "147", "< .001", "101.03", "113.07", "$.83$", "853.31", "1", "148", "< .001", "-270.97", "-267.96")
-        , Both = c("$1.86$ $[1.36$, $2.35]$", "$0.65$ $[0.52$, $0.78]$", "$0.71$ $[0.60$, $0.82]$", "$-0.56$ $[-0.81$, $-0.30]$", "$.86$ $[0.82$, $0.89]$", "295.54", "3", "146", "< .001", "84.64", "99.70", "$.02$", "19.04", "1", "148", "< .001", "-16.38", "-13.37")
+        , Length = c("$2.25$ $[1.76$, $2.74]$", "$0.60$ $[0.46$, $0.73]$", "$0.47$ $[0.44$, $0.51]$", "", "$.84$ $[0.79$, $0.87]$", "386.39", "2", "147", "< .001", "101.03", "113.07", "$.83$", "853.31", "1", "147", "< .001", "-270.97", "-267.96")
+        , Both = c("$1.86$ $[1.36$, $2.35]$", "$0.65$ $[0.52$, $0.78]$", "$0.71$ $[0.60$, $0.82]$", "$-0.56$ $[-0.81$, $-0.30]$", "$.86$ $[0.82$, $0.89]$", "295.54", "3", "146", "< .001", "84.64", "99.70", "$.02$", "19.04", "1", "146", "< .001", "-16.38", "-13.37")
       )
       , .Names = c("Baseline", "Length", "Both")
       , row.names = c("Intercept", "Sepal Width", "Petal Length", "Petal Width", "$R^2$ [90\\% CI]", "$F$", "$df_1$", "$df_2$", "$p$", "$\\mathrm{AIC}$", "$\\mathrm{BIC}$", "$\\Delta R^2$", "$F$ ", "$df_1$ ", "$df_2$ ", "$p$ ", "$\\Delta \\mathrm{AIC}$", "$\\Delta \\mathrm{BIC}$")
@@ -96,6 +96,27 @@ test_that(
     model_comp_boot2 <- apa_print(list(Baseline = mod1, Length = mod2), boot_samples = 1e3, ci = 0.5)
 
     expect_equal(model_comp_boot2$est$Length, "$\\Delta R^2 = .83$, 50\\% CI $[.80$, $.84]$")
+
+    # Correct df for model comparisons (issue #433)
+    comp1 <- apa_print(list(a = mod3, b = mod2, c = mod1), boot_samples = 0)
+    expect_identical(
+      comp1$statistic$b
+      , "$F(1, 146) = 19.04$, $p < .001$"
+    )
+    expect_identical(
+      comp1$statistic$c
+      , "$F(1, 146) = 853.31$, $p < .001$"
+    )
+    comp2 <- apa_print(list(a = mod2, b = mod1, c = mod3), boot_samples = 0)
+    expect_identical(
+      comp2$statistic$b
+      , "$F(1, 147) = 853.31$, $p < .001$"
+    )
+    expect_identical(
+      comp2$statistic$c
+      , "$F(2, 146) = 436.17$, $p < .001$"
+    )
+
   }
 )
 


### PR DESCRIPTION
This is a hotfix that fixes #433. Denominator degrees of freedom for differences in R² were always taken from the baseline model, but should be taken from the more-complex model. (Note that *p* values were still reported for the **correct** degrees of freedom, because we extracted these from the output of `anova.lmlist()`.)