### PR TITLE
patch for CSLReferences error

### DIFF
--- a/inst/rmarkdown/templates/revision_letter/resources/revision_letter.tex
+++ b/inst/rmarkdown/templates/revision_letter/resources/revision_letter.tex
@@ -141,10 +141,24 @@ $endfor$
 $if(csl-refs)$
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
-\newenvironment{cslreferences}%
-  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
-  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
-  {\par}
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
+ {% don't indent paragraphs
+  \setlength{\parindent}{0pt}
+  % turn on hanging indent if param 1 is 1
+  \ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
+  % set entry spacing
+  \ifnum #2 > 0
+  \setlength{\parskip}{#2\baselineskip}
+  \fi
+ }%
+ {}
+\usepackage{calc}
+\newcommand{\CSLBlock}[1]{#1\hfill\break}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
 
 \begin{document}

--- a/inst/rmarkdown/templates/revision_letter/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/revision_letter/skeleton/skeleton.Rmd
@@ -58,6 +58,6 @@ This is our response
 
 \begingroup
 
-<div id="refs" custom-style="Bibliography"></div>
+<div id="refs"></div>
 
 \endgroup

--- a/inst/rmarkdown/templates/revision_letter/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/revision_letter/skeleton/skeleton.Rmd
@@ -56,13 +56,8 @@ This is our response
 
 # References
 
-\noindent
-\vspace{-0.5cm}
-
 \begingroup
-\setlength{\parindent}{-0.5in}
-\setlength{\leftskip}{0.5in}
 
-<div id = "refs"></div>
+<div id="refs" custom-style="Bibliography"></div>
 
 \endgroup


### PR DESCRIPTION
As reported in issue #435 papaja::revision_letter is currently failing due to an update to pandoc's definition of the cslreferences environment.

@crsh suggested changes to the latex skeleton in order to fix this issue.

This pull request changes the revise and resubmit LaTeX and rmd skeletons in order to integrate these fixes.
