### PR TITLE
use centering instead of begin center

### DIFF
--- a/inst/rmarkdown/templates/apa6/resources/apa6_header_includes.tex
+++ b/inst/rmarkdown/templates/apa6/resources/apa6_header_includes.tex
@@ -13,8 +13,8 @@
 
 % Create new environments so endfloat can handle them
 % \newenvironment{ltable}
-%   {\begin{landscape}\begin{center}\begin{threeparttable}}
-%   {\end{threeparttable}\end{center}\end{landscape}}
+%   {\begin{landscape}\centering\begin{threeparttable}}
+%   {\end{threeparttable}\end{landscape}}
 \newenvironment{lltable}{\begin{landscape}\centering\begin{ThreePartTable}}{\end{ThreePartTable}\end{landscape}}
 
 % Enables adjusting longtable caption width to table width

--- a/inst/rmarkdown/templates/apa6/resources/apa6_header_includes.tex
+++ b/inst/rmarkdown/templates/apa6/resources/apa6_header_includes.tex
@@ -15,7 +15,7 @@
 % \newenvironment{ltable}
 %   {\begin{landscape}\begin{center}\begin{threeparttable}}
 %   {\end{threeparttable}\end{center}\end{landscape}}
-\newenvironment{lltable}{\begin{landscape}\begin{center}\begin{ThreePartTable}}{\end{ThreePartTable}\end{center}\end{landscape}}
+\newenvironment{lltable}{\begin{landscape}\centering\begin{ThreePartTable}}{\end{ThreePartTable}\end{landscape}}
 
 % Enables adjusting longtable caption width to table width
 % Solution found at http://golatex.de/longtable-mit-caption-so-breit-wie-die-tabelle-t15767.html


### PR DESCRIPTION
This PR changes the `\begin{center}` to `\centering` in a table environment. The centering environment adds a little space that may add an empty pace in certain circumstances. This is not the case with `\centering`.

See also: https://tex.stackexchange.com/questions/23650/when-should-we-use-begincenter-instead-of-centering