### PR TITLE
Encoding-related fixes

### DIFF
--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -763,14 +763,18 @@ revert_original_input_file <- function(x = 1) {
   return(NULL)
 }
 
+
+
 #' @keywords internal
 
 readLines_utf8 <- function(con) {
   if(is.character(con)) {
     con <- file(con, encoding = "utf8")
     on.exit(close(con))
+  } else if(inherits(con, "connection")) {
+    stop("If you want to use an already existing connection, you should use readLines(), directly.")
   }
   y <- try(readLines(con, encoding = "bytes"))
-  if(inherits(y, "try-error")) stop("File ", summary(con)$description, " seems to be missing.")
+  if(inherits(y, "try-error")) stop("Reading from file ", encodeString(summary(con)$description, quote = "'"), " failed.")
   y
 }

--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -708,9 +708,7 @@ replace_yaml_front_matter <- function(x, input_text, input_file) {
 
 
 modify_input_file <- function(input, format) {
-  input_connection <- file(input, encoding = "UTF-8")
-  on.exit(close.connection(input_connection))
-  input_text <- readLines(con = input_connection)
+  input_text <- readLines_utf8(con = basename(input))
 
   yaml_params <- get_yaml_params(input_text)
 
@@ -738,9 +736,8 @@ modify_input_file <- function(input, format) {
           , ""
         )
       }
-      # useBytes set to FALSE due to issue #446, but this might cause trouble with
-      # CJK characters
-      writeLines(input_text, input_connection, useBytes = FALSE)
+      # latest changes due to issue #446
+      writeLines(input_text, con = input, useBytes = TRUE)
     }
   }
 
@@ -764,4 +761,16 @@ revert_original_input_file <- function(x = 1) {
   }
 
   return(NULL)
+}
+
+#' @keywords internal
+
+readLines_utf8 <- function(con) {
+  if(is.character(con)) {
+    con <- file(con, encoding = "utf8")
+    on.exit(close(con))
+  }
+  y <- try(readLines(con, encoding = "bytes"))
+  if(inherits(y, "try-error")) stop("File ", summary(con)$description, " seems to be missing.")
+  y
 }


### PR DESCRIPTION
Hi @crsh,

pending feedback from @kalenkovich, I think issues #446 and #353 should be resolved with the changes proposed here. Basically, the code now ensures that whenever a file is read, it is read as unicode (as both Unixes and Windows are capable of). Whenever a file is written, it is written byte-by-byte, because Windows does not seem to support writing unicode, yet. For reference, here is the crucial part of the documentation of `file()`:

> When **writing** to a text connection, the connections code always assumes its input is in native encoding, so e.g. **writeLines has to convert text to native encoding**. writeLines does not do the conversion when useBytes=TRUE (for expert use only), but the connections code still behaves as if the text was in native encoding, **so any attempt to convert encoding** (encoding argument other than "" and "native.enc") **in connections will produce incorrect results.**
>
> When **reading** from a text connection, the connections code, after re-encoding based on the encoding argument, returns text that is assumed to be in native encoding; an encoding mark is only added by functions that read from the connection, so e.g. readLines can be instructed to mark the text as "UTF-8" or "latin1", but readLines does no further conversion. **To allow reading text in "UTF-8" on a system that cannot represent all such characters in native encoding (currently only Windows), a connection can be internally configured to return the read text in UTF-8 even though it is not the native encoding**; currently readLines and scan use this feature when given a connection that is not yet open and, when using the feature, they unconditionally mark the text as "UTF-8". 

This boils down to the following technique:
```
# for reading a new internal function that ensures that the connection is opened correctly:
readLines_utf8()

# for writing
writeLines(text, con, useBytes = TRUE)
```
