### PR TITLE
Hot fix: Safer detection of Chi^2 test in stat_glue(). #154

### DIFF
--- a/R/glue_apa_results.R
+++ b/R/glue_apa_results.R
@@ -223,7 +223,7 @@ stat_glue <- function(x) {
     if(!is.null(x$df.residual)) {
       df <- "(<<df>>, <<df.residual>>)"
     } else if( # Chi^2-Test
-      variable_labels(x$statistic) == "$\\chi^2$" &&
+      identical(variable_label(x$statistic), "$\\chi^2$") &&
       exists("n", where = parent.frame(2), mode = "numeric") &&
       !is.null(get("n", envir = parent.frame(2), mode = "numeric"))
     ) {

--- a/R/glue_apa_results.R
+++ b/R/glue_apa_results.R
@@ -223,8 +223,9 @@ stat_glue <- function(x) {
     if(!is.null(x$df.residual)) {
       df <- "(<<df>>, <<df.residual>>)"
     } else if( # Chi^2-Test
-      exists("n", where = parent.frame(2)) &&
-      !is.null(get("n", envir = parent.frame(2)))
+      variable_labels(x$statistic) == "$\\chi^2$" &&
+      exists("n", where = parent.frame(2), mode = "numeric") &&
+      !is.null(get("n", envir = parent.frame(2), mode = "numeric"))
     ) {
       df <- "(<<df>>, n = <<n>>)"
     } else {

--- a/tests/testthat/test_apa_print_merMod.R
+++ b/tests/testthat/test_apa_print_merMod.R
@@ -298,5 +298,46 @@ test_that(
         , N_P = "$\\chi^2(1) = 1.18$, $p = .277$"
       )
     )
+
+    # https://github.com/crsh/papaja/issues/154#issuecomment-892189864
+    participant<-c("vp1","vp2","vp3","vp4","vp5")
+    group<-c("intervention", "control","control","intervention","control")
+
+    library("dplyr")
+    df<-data.frame(participant,group) %>%
+      group_by(participant,group) %>%
+      summarise(session=c("t1","t2","t3","t4")) %>%
+      group_by(participant, group, session) %>%
+      summarise(task=c("a","b")) %>%
+      ungroup() %>%
+      mutate(errors=floor(runif(n=40,min=0,max=30)))
+
+    glmm <- afex::mixed(errors~group*session*task+(1|participant), df)
+    apa_t <- apa_print(glmm$full_model)
+
+    expect_apa_results(
+      apa_t
+      , labels = list(
+        term        = "Term"
+        , estimate  = "$\\hat{\\beta}$"
+        , conf.int  = "95\\% CI"
+        , statistic = "$t$"
+        , df        = "$\\mathit{df}$"
+        , p.value   = "$p$"
+      )
+    )
+
+    glmm <- afex::mixed(errors~group*session*task+(1|participant), df, family = "poisson", method = "LRT")
+    apa_LRT <- apa_print(glmm)
+
+    expect_apa_results(
+      apa_LRT
+      , labels = list(
+        term        = "Effect"
+        , statistic = "$\\chi^2$"
+        , df        = "$\\mathit{df}$"
+        , p.value   = "$p$"
+      )
+    )
   }
 )


### PR DESCRIPTION
The problem in #154 seems to be that `stat_glue()` tries to determine, whether there is sample size information in an fundamentally unsafe way. This is a hot fix for the issue, but requires a lot more thought.