### PR TITLE
Adds n as attribute to $statistic for htest

### DIFF
--- a/R/apa_print_htest.R
+++ b/R/apa_print_htest.R
@@ -153,6 +153,8 @@ apa_print.htest <- function(
       stop("Please provide the sample size to report.")
     # } else {
     #   n <- paste0(", n = ", n)
+    } else {
+      attr(x$statistic, "n") <- as.integer(n)
     }
   } else {
     n <- NULL

--- a/R/apa_print_htest.R
+++ b/R/apa_print_htest.R
@@ -154,7 +154,7 @@ apa_print.htest <- function(
     # } else {
     #   n <- paste0(", n = ", n)
     } else {
-      attr(x$statistic, "n") <- as.integer(n)
+      attr(x$statistic, "n") <- printnum(as.integer(n))
     }
   } else {
     n <- NULL

--- a/R/glue_apa_results.R
+++ b/R/glue_apa_results.R
@@ -224,8 +224,8 @@ stat_glue <- function(x) {
       df <- "(<<df>>, <<df.residual>>)"
     } else if( # Chi^2-Test
       identical(variable_label(x$statistic), "$\\chi^2$") &&
-      exists("n", where = parent.frame(2), mode = "numeric") &&
-      !is.null(get("n", envir = parent.frame(2), mode = "numeric"))
+      !is.null(attr(x$statistic, "n")) &&
+      is.integer(attr(x$statistic, "n"))
     ) {
       df <- "(<<df>>, n = <<n>>)"
     } else {

--- a/R/glue_apa_results.R
+++ b/R/glue_apa_results.R
@@ -222,10 +222,9 @@ stat_glue <- function(x) {
   if(!is.null(x$df)) {
     if(!is.null(x$df.residual)) {
       df <- "(<<df>>, <<df.residual>>)"
-    } else if( # Chi^2-Test
+    } else if(
       identical(variable_label(x$statistic), "$\\chi^2$") &&
-      !is.null(attr(x$statistic, "n")) &&
-      is.integer(attr(x$statistic, "n"))
+      !is.null(attr(x$statistic, "n"))
     ) {
       df <- "(<<df>>, n = <<n>>)"
     } else {

--- a/tests/testthat/helper-structure.R
+++ b/tests/testthat/helper-structure.R
@@ -93,16 +93,16 @@ expect_apa_results <- function(
 # Test the test, work in progress ----
 # expect_failure() somehow doesn't detect failure
 
-test_that(
-  "expect_apa_results"
-  , {
-    test <- papaja:::init_apa_results()
-    test$table <- data.frame(a = 1)
-
-    # class(test$table) <- c("apa_results_table", "data.frame")
-    # expect_failure(
-    #   expect_apa_results(test)
-    #   , "has class"
-    # )
-  }
-)
+# test_that(
+#   "expect_apa_results"
+#   , {
+#     test <- papaja:::init_apa_results()
+#     test$table <- data.frame(a = 1)
+#
+#     class(test$table) <- c("apa_results_table", "data.frame")
+#     expect_failure(
+#       expect_apa_results(test)
+#       , "has class"
+#     )
+#   }
+# )

--- a/tests/testthat/test_apa_print_htest.R
+++ b/tests/testthat/test_apa_print_htest.R
@@ -270,6 +270,10 @@ test_that(
       )
     )
 
+    expect_identical(
+      attr(two_sample_prop_test_output$table$statistic, "n")
+      , as.integer(sum(patients[3:4]))
+    )
   }
 )
 

--- a/tests/testthat/test_apa_print_htest.R
+++ b/tests/testthat/test_apa_print_htest.R
@@ -272,7 +272,7 @@ test_that(
 
     expect_identical(
       attr(two_sample_prop_test_output$table$statistic, "n")
-      , as.integer(sum(patients[3:4]))
+      , printnum(as.integer(sum(patients[3:4])))
     )
   }
 )


### PR DESCRIPTION
This PR addresses #470. I briefly considered passing `n` via `...` to `stat_glue()`, which would grant the flexibility to add all sorts of options if needed. While I think this is generally a useful approach, for the time being there seems to be no need to complicate things

@mariusbarth [suggested](https://github.com/crsh/papaja/pull/469):

> To further improve stability, I think we could switch to an additional attribute for the statistic column (e.g., attr(x$statistic, "n").

This works just as well and has the benefit that this way we provide all information of interest with the `apa_results_table` returned by `apa_print()`. So even if, at a later point, we decide to also use `...` as outlined above, I think adding the attribute makes sense. So for now, we should leave it at that.