### PR TITLE
Use absolute file paths for custom CSL. Fixes #482

### DIFF
--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -405,7 +405,7 @@ pdf_pre_processor <- function(metadata, input_file, runtime, knit_meta, files_di
     ## Set ampersand filter
     if((is.null(metadata$replace_ampersands) || metadata$replace_ampersands)) {
       if(csl_specified) {
-        args <- c(args, "--csl", metadata$csl)
+        args <- c(args, "--csl", rmarkdown::pandoc_path_arg(tools::file_path_as_absolute(metadata$csl)))
       }
 
       args <- rmdfiltr::add_citeproc_filter(args)
@@ -626,7 +626,7 @@ pdf_pre_processor <- function(metadata, input_file, runtime, knit_meta, files_di
 
   ## Add appendix
   if(!is.null(metadata$appendix)) {
-    appendices <- sapply(metadata$appendix, function(x) tools::file_path_sans_ext(tools::file_path_as_absolute(x)))
+    appendices <- sapply(metadata$appendix, function(x) rmarkdown::pandoc_path_arg(tools::file_path_sans_ext(tools::file_path_as_absolute(x))))
     args <- c(args, paste0("--include-after-body=", appendices, ".tex"))
   }
 
@@ -673,7 +673,7 @@ word_pre_processor <- function(metadata, input_file, runtime, knit_meta, files_d
     ## Set ampersand filter
     if((is.null(metadata$replace_ampersands) || metadata$replace_ampersands)) {
       if(csl_specified) {
-        args <- c(args, "--csl", metadata$csl)
+        args <- c(args, "--csl", rmarkdown::pandoc_path_arg(tools::file_path_as_absolute(metadata$csl)))
       }
 
       args <- rmdfiltr::add_citeproc_filter(args)

--- a/R/render_appendix.R
+++ b/R/render_appendix.R
@@ -75,7 +75,7 @@ render_appendix <- function(
       )
     }
 
-    csl_call <- paste0("--csl=", csl)
+    csl_call <- paste0("--csl=", rmarkdown::pandoc_path_arg(tools::file_path_as_absolute(csl)))
   } else {
     bib_call <- gsub("^--", "-M ", bib_call)
     csl_call <- NULL


### PR DESCRIPTION
This PR makes it possible to specifying bibliography, appendix, and CSL files. @shirdekel when it's convenient for you, could you try whether this resolves the issue for you?

~~~r
remotes::install_github("crsh/papaja@crsh/issue482")
~~~