### PR TITLE
Allow gt1 argument for apa_print() and printp()

### DIFF
--- a/R/apa_print_emm_lsm.R
+++ b/R/apa_print_emm_lsm.R
@@ -125,7 +125,7 @@ apa_print.summary_emm <- function(
     contrast_table <- rename_column(contrast_table, c("t.ratio", "z.ratio"), "statistic")
     contrast_table$statistic <- printnum(contrast_table$statistic)
     contrast_table$df <- printnum(contrast_table$df, digits = dfdigits)
-    contrast_table$p.value <- printp(contrast_table$p.value)
+    contrast_table$p.value <- printp(contrast_table$p.value, ...)
   }
 
   if(ci_supplied) {

--- a/R/apa_print_glht.R
+++ b/R/apa_print_glht.R
@@ -72,7 +72,7 @@ apa_print.summary.glht <- function(
   ## Format numbers
   contrast_table$estimate <- printnum(contrast_table$estimate, ...)
   contrast_table$statistic <- printnum(contrast_table$statistic, digits = 2)
-  contrast_table$p.value <- printp(contrast_table$p.value)
+  contrast_table$p.value <- printp(contrast_table$p.value, ...)
 
   # Concatenate character strings and return as named list
   apa_res <- apa_print_container()
@@ -209,7 +209,7 @@ apa_print.summary.glht <- function(
 #   if(p_supplied) {
 #     contrast_table$statistic <- printnum(contrast_table$statistic)
 #     contrast_table$df <- printnum(contrast_table$df, digits = dfdigits)
-#     contrast_table$p.value <- printp(contrast_table$p.value)
+#     contrast_table$p.value <- printp(contrast_table$p.value, ...)
 #   }
 #
 #   # Concatenate character strings and return as named list

--- a/R/apa_print_glm.R
+++ b/R/apa_print_glm.R
@@ -178,8 +178,10 @@ apa_print.lm <- function(
 
   ellipsis <- list(...)
 
+  if(is.null(ellipsis$gt1)) glm_gt1 <- FALSE else glm_gt1 <- ellipsis$gt1
+
   if(is.null(est_name)) if(standardized) est_name <- "b^*" else est_name <- "b"
-  if(standardized) ellipsis$gt1 <- FALSE
+  if(standardized) ellipsis$gt1 <- glm_gt1
 
   if(is.matrix(ci)) {
     conf_level <- as.numeric(gsub("[^.|\\d]", "", colnames(ci), perl = TRUE))
@@ -206,7 +208,7 @@ apa_print.lm <- function(
   summary_x <- summary(x)
   glance_x <- broom::glance(x)
 
-  p <- printp(glance_x$p.value)
+  p <- printp(glance_x$p.value, ...)
   p <- add_equals(p)
 
   apa_res$statistic$modelfit$r2 <- paste0("$F(", summary_x$fstatistic[2], ", ", glance_x$df.residual, ") = ", printnum(glance_x$statistic), "$, $p ", p, "$") # glance_x$df
@@ -227,13 +229,13 @@ apa_print.lm <- function(
     )
 
     if(!any(is.na(c(r2_ci$Lower, r2_ci$Upper)))) { # MBESS::ci.R2 can sometimes result in NA if F is really small
-      apa_res$estimate$modelfit$r2 <- paste0("$R^2 = ", printnum(glance_x$r.squared, gt1 = FALSE, zero = FALSE), "$, ", print_confint(c(r2_ci$Lower, r2_ci$Upper), conf_level = ci_conf_level))
+      apa_res$estimate$modelfit$r2 <- paste0("$R^2 = ", printnum(glance_x$r.squared, gt1 = glm_gt1, zero = FALSE), "$, ", print_confint(c(r2_ci$Lower, r2_ci$Upper), conf_level = ci_conf_level))
     }
   } else {
-    apa_res$estimate$modelfit$r2 <- paste0("$R^2 = ", printnum(glance_x$r.squared, gt1 = FALSE, zero = FALSE), "$")
+    apa_res$estimate$modelfit$r2 <- paste0("$R^2 = ", printnum(glance_x$r.squared, gt1 = glm_gt1, zero = FALSE), "$")
   }
 
-  apa_res$estimate$modelfit$r2_adj <- paste0("$R^2_{adj} = ", printnum(glance_x$adj.r.squared, gt1 = FALSE, zero = FALSE), "$")
+  apa_res$estimate$modelfit$r2_adj <- paste0("$R^2_{adj} = ", printnum(glance_x$adj.r.squared, gt1 = glm_gt1, zero = FALSE), "$")
   apa_res$estimate$modelfit$aic <- paste0("$\\mathrm{AIC} = ", printnum(glance_x$AIC), "$")
   apa_res$estimate$modelfit$bic <- paste0("$\\mathrm{BIC} = ", printnum(glance_x$BIC), "$")
 

--- a/R/apa_print_htest.R
+++ b/R/apa_print_htest.R
@@ -110,7 +110,7 @@ apa_print.htest <- function(
   }
 
   # p-value
-  p <- printp(x$p.value)
+  p <- printp(x$p.value, ...)
 
   apa_res <- apa_print_container()
   apa_res$statistic <- paste0("$", stat_name, " = ", stat, "$, $p ", add_equals(p), "$")

--- a/R/apa_print_manova.R
+++ b/R/apa_print_manova.R
@@ -34,6 +34,7 @@ apa_print.manova <- function(x, test = "Pillai", ...) {
 print_manova <- function(
   x
   , in_paren = FALSE
+  , ...
 ) {
 
 
@@ -86,7 +87,7 @@ print_manova <- function(
   x[["F"]] <- printnum(x[["F"]])
   x[["df1"]] <- print_df(x[["df1"]])
   x[["df2"]] <- print_df(x[["df2"]])
-  x[["p"]] <- printp(x[["p"]])
+  x[["p"]] <- printp(x[["p"]], ...)
 
   x <- sort_terms(x, "Effect")
 

--- a/R/apa_print_merMod.R
+++ b/R/apa_print_merMod.R
@@ -90,7 +90,7 @@
 #'
 #'   if(isLmerTest) {
 #'     res_table$df <- print_df(res_table$df)
-#'     res_table$p.value <- printp(res_table$p.value)
+#'     res_table$p.value <- printp(res_table$p.value, ...)
 #'     res_table <- res_table[, c(est_cols, "df", "p.value")]
 #'   } else {
 #'     res_table <- res_table[, est_cols]

--- a/R/arrange_regression.R
+++ b/R/arrange_regression.R
@@ -25,7 +25,7 @@ arrange_regression <- function(x, est_name, standardized, ci, ...) {
   } else if(class(x) == "lm") {
     stat_name <- "t"
     if(is.null(est_name)) if(standardized) est_name <- "b^*" else est_name <- "b"
-    if(standardized) ellipsis$gt1 <- FALSE
+    if(standardized & is.null(ellipsis$gt1)) ellipsis$gt1 <- FALSE
   }
 
   if(is.matrix(ci)) {
@@ -51,7 +51,7 @@ arrange_regression <- function(x, est_name, standardized, ci, ...) {
 
   regression_table$estimate <- do.call(function(...) printnum(regression_table$estimate, ...), ellipsis)
   regression_table$statistic <- printnum(regression_table$statistic, digits = 2)
-  regression_table$p.value <- printp(regression_table$p.value)
+  regression_table$p.value <- printp(regression_table$p.value, ...)
 
   colnames(regression_table) <- c("predictor", "estimate", "ci", "statistic", "p.value")
 

--- a/R/print_anova.R
+++ b/R/print_anova.R
@@ -41,6 +41,7 @@ print_anova <- function(
   , es = "ges"
   , mse = getOption("papaja.mse")
   , in_paren = FALSE
+  , ...
 ) {
 
   # When processing aovlist objects, the `(Intercept)` is kept to preserve the
@@ -49,6 +50,9 @@ print_anova <- function(
   validate(x, check_class = "data.frame", check_NA = FALSE)
   validate(x, check_class = "apa_variance_table", check_NA = FALSE)
   validate(intercept, check_class = "logical", check_length = 1)
+
+  ellipsis <- list(...)
+  if(is.null(ellipsis$gt1)) apa_gt1 <- FALSE else apa_gt1 <- ellipsis$gt1
 
   if(!is.null(observed)) validate(observed, check_class = "character")
   if(!is.null(es)) {
@@ -73,10 +77,10 @@ print_anova <- function(
 
   # Rounding and filling with zeros
   x$statistic <- printnum(x$statistic, digits = 2)
-  x$p.value <- printp(x$p.value)
+  x$p.value <- printp(x$p.value, ...)
   x$df <- print_df(x$df)
   x$df_res <- print_df(x$df_res)
-  for(i in es) {x[[i]] <- printnum(x[[i]], digits = 3, gt1 = FALSE)}
+  for(i in es) {x[[i]] <- printnum(x[[i]], digits = 3, gt1 = apa_gt1)}
   if(mse) x$mse <- printnum(x$mse, digits = 2)
 
   # Assemble table -------------------------------------------------------------

--- a/R/printnum.R
+++ b/R/printnum.R
@@ -375,12 +375,12 @@ printnumber <- function(x, gt1 = TRUE, zero = TRUE, na_string = "", use_math = T
 #' printp(0.99999999)
 #' @export
 
-printp <- function(x, digits = 3L, na_string = "", add_equals = FALSE) {
+printp <- function(x, digits = 3L, na_string = "", add_equals = FALSE, gt1 = FALSE) {
   validate(x, check_class = "numeric", check_range = c(0, 1), check_NA = FALSE)
   validate(na_string, check_class = "character", check_length = 1)
   validate(digits, check_class = "numeric")
 
-  p <- printnum(x, digits = digits, gt1 = FALSE, zero = FALSE, na_string = na_string, add_equals = add_equals)
+  p <- printnum(x, digits = digits, gt1 = gt1, zero = FALSE, na_string = na_string, add_equals = add_equals)
   p
 }
 


### PR DESCRIPTION
While APA style omits the initial zero for values ranging between -1 to 1, other publishers don't have this requirement, and I publish in non-APA journals and would like to use `apa_print()` for those journals. 

I changed a number of the `apa_print()` functions and `printp()` to allow for initial zeros if the `gt1` argument is included. The default is always to have no inital zeros, but this can be overridden with `gt1 =TRUE`. This involved adding `...` as an argument to some of the functions and checking for the presence of `ellipse$gt1`. 

I tested all of the changed functions with the examples (for functions that had examples), and they all worked fine.

I'm happy to conduct further testing if request, or let me know if there are better ways to implement what I have suggested.