### PR TITLE
Attempt at fixing platform-specific number of trailing digits

### DIFF
--- a/R/apa_num.R
+++ b/R/apa_num.R
@@ -411,12 +411,14 @@ printp <- apa_p
 print_p <- apa_p
 
 
-#' Print Degrees of Freedom
+#' Typeset Degrees of Freedom
 #'
-#' This is an internal function for processing degrees of freedom. It takes care
+#' This is a function for processing degrees of freedom. It takes care
 #' that trailing digits are only printed if non-integer values are given.
 #'
-#' @keywords internal
+#' @param x Numeric. The degrees of freedom to report.
+#' @param digits Integer. The desired number of digits after the decimal point to
+#'   be used if `x` contains non-integer values.
 #' @export
 
 apa_df <- function(x, digits = 2L) {
@@ -430,13 +432,13 @@ apa_df <- function(x, digits = 2L) {
     stop("The parameter `digits` must be of length 1 or equal to length of `x`.")
   }
 
-  x_digits <- ifelse(
-    is.finite(x)
-    , as.integer(x %% 1 > 0) * digits
-    , 0L
-  )
+  if( all(round(x, digits = 0L) == round(x, digits = digits + 2L)) ) {
+    digits <- 0L
+  } else {
+    digits <- as.integer(digits)
+  }
 
-  return(apa_num(x, digits = x_digits))
+  apa_num(x, digits = digits)
 }
 
 #' @rdname apa_df

--- a/R/apa_num.R
+++ b/R/apa_num.R
@@ -419,12 +419,18 @@ print_p <- apa_p
 #' @param x Numeric. The degrees of freedom to report.
 #' @param digits Integer. The desired number of digits after the decimal point to
 #'   be used if `x` contains non-integer values.
+#' @param elementwise Logical. Determines whether the number of trailing digits
+#'   should be determined for each element of `x` separately (the default),
+#'   or for the complete vector `x`.
 #' @export
 
-apa_df <- function(x, digits = 2L) {
+apa_df <- function(x, digits = 2L, elementwise = TRUE) {
 
   if(is.null(x))    return(NULL)
   if(is.integer(x)) return(apa_num(x))
+
+  elementwise <- isTRUE(elementwise)
+  digits <- as.integer(digits)
 
   validate(digits, check_class = "numeric", check_NA = TRUE)
 
@@ -432,10 +438,10 @@ apa_df <- function(x, digits = 2L) {
     stop("The parameter `digits` must be of length 1 or equal to length of `x`.")
   }
 
-  if( all(round(x, digits = 0L) == round(x, digits = digits + 2L)) ) {
+  if(elementwise) {
+    digits <- as.integer(round(x, digits = 0L) != round(x, digits = digits + 2L)) * digits
+  } else if( all(round(x, digits = 0L) == round(x, digits = digits + 2L)) ) {
     digits <- 0L
-  } else {
-    digits <- as.integer(digits)
   }
 
   apa_num(x, digits = digits)

--- a/man/apa_df.Rd
+++ b/man/apa_df.Rd
@@ -5,15 +5,19 @@
 \alias{print_df}
 \title{Typeset Degrees of Freedom}
 \usage{
-apa_df(x, digits = 2L)
+apa_df(x, digits = 2L, elementwise = TRUE)
 
-print_df(x, digits = 2L)
+print_df(x, digits = 2L, elementwise = TRUE)
 }
 \arguments{
 \item{x}{Numeric. The degrees of freedom to report.}
 
 \item{digits}{Integer. The desired number of digits after the decimal point to
 be used if \code{x} contains non-integer values.}
+
+\item{elementwise}{Logical. Determines whether the number of trailing digits
+should be determined for each element of \code{x} separately (the default),
+or for the complete vector \code{x}.}
 }
 \description{
 This is a function for processing degrees of freedom. It takes care

--- a/man/apa_df.Rd
+++ b/man/apa_df.Rd
@@ -3,14 +3,19 @@
 \name{apa_df}
 \alias{apa_df}
 \alias{print_df}
-\title{Print Degrees of Freedom}
+\title{Typeset Degrees of Freedom}
 \usage{
 apa_df(x, digits = 2L)
 
 print_df(x, digits = 2L)
 }
+\arguments{
+\item{x}{Numeric. The degrees of freedom to report.}
+
+\item{digits}{Integer. The desired number of digits after the decimal point to
+be used if \code{x} contains non-integer values.}
+}
 \description{
-This is an internal function for processing degrees of freedom. It takes care
+This is a function for processing degrees of freedom. It takes care
 that trailing digits are only printed if non-integer values are given.
 }
-\keyword{internal}

--- a/tests/testthat/test_apa_print_emm_lsm.R
+++ b/tests/testthat/test_apa_print_emm_lsm.R
@@ -446,12 +446,13 @@ test_that(
       , term_names = names(tw_rm_output$estimate)
     )
 
-    expect_apa_term(
-      emm_aov_output
-      , term = "Task"
-      , estimate = NULL
-      , statistic = tw_rm_output$statistic$Task
-    )
+    # Rounding is different for different tables
+    # expect_apa_term(
+    #   emm_aov_output
+    #   , term = "Task"
+    #   , estimate = NULL
+    #   , statistic = tw_rm_output$statistic$Task
+    # )
 
     ## Split by
     emm_split_aov <- emmeans::joint_tests(tw_rm_emm, by = "Task")

--- a/tests/testthat/test_apa_print_emm_lsm.R
+++ b/tests/testthat/test_apa_print_emm_lsm.R
@@ -446,13 +446,13 @@ test_that(
       , term_names = names(tw_rm_output$estimate)
     )
 
-    # Rounding is different for different tables
-    # expect_apa_term(
-    #   emm_aov_output
-    #   , term = "Task"
-    #   , estimate = NULL
-    #   , statistic = tw_rm_output$statistic$Task
-    # )
+
+    expect_apa_term(
+      emm_aov_output
+      , term = "Task"
+      , estimate = NULL
+      , statistic = tw_rm_output$statistic$Task
+    )
 
     ## Split by
     emm_split_aov <- emmeans::joint_tests(tw_rm_emm, by = "Task")

--- a/tests/testthat/test_apa_print_merMod.R
+++ b/tests/testthat/test_apa_print_merMod.R
@@ -191,7 +191,7 @@ test_that(
 
     expect_identical(
       apa_KR$full_result$Days
-      , expected = "$F(1, 17.00) = 45.85$, $p < .001$"
+      , expected = "$F(1, 17) = 45.85$, $p < .001$"
     )
     expect_identical(
       apa_S$full_result$Days
@@ -279,9 +279,9 @@ test_that(
     expect_identical(
       object = apa_KR$statistic
       , expected = list(
-        N = "$F(1, 15.00) = 9.04$, $p = .009$"
-        , P = "$F(1, 15.00) = 0.40$, $p = .536$"
-        , N_P = "$F(1, 15.00) = 1.02$, $p = .329$"
+        N = "$F(1, 15) = 9.04$, $p = .009$"
+        , P = "$F(1, 15) = 0.40$, $p = .536$"
+        , N_P = "$F(1, 15) = 1.02$, $p = .329$"
       )
     )
     expect_identical( # KR gives same results as S in this special case

--- a/tests/testthat/test_apa_print_merMod.R
+++ b/tests/testthat/test_apa_print_merMod.R
@@ -56,14 +56,14 @@ test_that(
       object = apa_lmerTest$statistic
       , expected = list(
         Intercept = "$t(8.17) = 27.06$, $p < .001$"
-        , N1 = "$t(17.00) = 3.06$, $p = .007$"
+        , N1 = "$t(17) = 3.06$, $p = .007$"
       )
     )
     expect_identical(
       object = apa_lmerTest$full_result
       , expected = list(
         Intercept = "$\\hat{\\beta} = 52.07$, 95\\% CI $[48.29, 55.84]$, $t(8.17) = 27.06$, $p < .001$"
-        , N1 = "$\\hat{\\beta} = 5.62$, 95\\% CI $[2.02, 9.21]$, $t(17.00) = 3.06$, $p = .007$"
+        , N1 = "$\\hat{\\beta} = 5.62$, 95\\% CI $[2.02, 9.21]$, $t(17) = 3.06$, $p = .007$"
       )
     )
 
@@ -88,7 +88,7 @@ test_that(
 
     expect_identical( # in_paren
       object = apa_lmerTest_specialties$full_result$N1
-      , expected = "$\\gamma = 5.6167$, 96\\% CI $[1.8462, 9.3871]$, $t[17.00] = 3.06$, $p = .007$"
+      , expected = "$\\gamma = 5.6167$, 96\\% CI $[1.8462, 9.3871]$, $t[17] = 3.06$, $p = .007$"
     )
 
     # Test reduction of (Days | Subject) to (1 | Subject):


### PR DESCRIPTION
- apa_df() now compares rounded vectors, instead of using the modulus operator
- new implementation should be robust against class extensions (e.g., 'tiny_labelled') of standard vectors
- also updated docs of `apa_df()` to reflect that it is now exported
- as a side effect, integer degrees of freedom are now more frequently reported (for HLM and emmeans methods)