### PR TITLE
apa_num: Check if x is too small before rounding.

### DIFF
--- a/R/apa_num.R
+++ b/R/apa_num.R
@@ -230,9 +230,6 @@ apa_num.numeric <- function(
   is_scientific <- rep(tolower(ellipsis$format), length.out = length_x) %in% c("e", "g", "fg")
 
   ten_power_digits <- 10^digits
-  x[!is_scientific] <- 0 + round(x[!is_scientific] * ten_power_digits[!is_scientific]) / ten_power_digits[!is_scientific]
-
-
 
   if(any(not_zero)) {
 
@@ -244,6 +241,8 @@ apa_num.numeric <- function(
 
     prepend[abs_too_small] <- ifelse(is_negative[abs_too_small], "> ", "< ")
   }
+
+  x[!is_scientific] <- 0 + round(x[!is_scientific] * ten_power_digits[!is_scientific]) / ten_power_digits[!is_scientific]
 
   if(any(not_gt1)) {
     if(any(not_gt1 & abs(x) > 1, na.rm = TRUE)) warning("You specified gt1 = FALSE, but passed absolute value(s) that exceed 1.")

--- a/tests/testthat/test_apa_print_emm_lsm.R
+++ b/tests/testthat/test_apa_print_emm_lsm.R
@@ -134,7 +134,7 @@ test_that(
       tw_int_emm_output
       , term = "Neg_Cued"
       , estimate = "$M = 11.80$, 95\\% CI $[7.17, 16.43]$"
-      , statistic = "$t(5.52) = 6.37$, $p = .001$"
+      , statistic = "$t(5.52) = 6.37$, $p < .001$"
     )
 
     # Alternative calls


### PR DESCRIPTION
To address #536, I deferred rounding in `apa_num()` until after the checks if the value is small enough to require a prefix (`<` or `>`) have been run.