### PR TITLE
Suppresses numbering of abstract in man-mode.

### DIFF
--- a/R/apa6_formats.R
+++ b/R/apa6_formats.R
@@ -25,7 +25,7 @@
 #'   When creating PDF documents the output device for figures defaults to
 #'   \code{c("pdf", "png")}, so that each figure is saved in all four formats
 #'   at a resolution of 300 dpi.
-#' @return R Markdown output format to pass to [rmarkdown::render()]
+#' @return R Markdown output format to pass to [rmarkdown::render()].
 #' @seealso [bookdown::pdf_document2()], [bookdown::word_document2()]
 #' @export
 
@@ -437,6 +437,7 @@ pdf_pre_processor <- function(metadata, input_file, runtime, knit_meta, files_di
       metadata$lang
       , english = "en-EN"
       , american = "en-US"
+      , german = "de-DE"
       , metadata$lang
     )
   }

--- a/inst/rmarkdown/templates/apa6/resources/apa6_header_includes.tex
+++ b/inst/rmarkdown/templates/apa6/resources/apa6_header_includes.tex
@@ -42,17 +42,11 @@
   {\normalfont\normalsize\itshape\hspace{\parindent}{#1}\textit{\addperi}}{\relax}}
 \makeatother
 
-% \usepackage{etoolbox}
-\makeatletter
-\patchcmd{\HyOrg@maketitle}
+\usepackage{etoolbox}
+\patchcmd{\maketitle}
   {\section{\normalfont\normalsize\abstractname}}
   {\section*{\normalfont\normalsize\abstractname}}
   {}{\typeout{Failed to patch abstract.}}
-\patchcmd{\HyOrg@maketitle}
-  {\section{\protect\normalfont{\@title}}}
-  {\section*{\protect\normalfont{\@title}}}
-  {}{\typeout{Failed to patch title.}}
-\makeatother
 
 \usepackage{xpatch}
 \makeatletter

--- a/inst/rmarkdown/templates/apa6/resources/apa6_header_includes.tex
+++ b/inst/rmarkdown/templates/apa6/resources/apa6_header_includes.tex
@@ -42,11 +42,17 @@
   {\normalfont\normalsize\itshape\hspace{\parindent}{#1}\textit{\addperi}}{\relax}}
 \makeatother
 
+\makeatletter
 \usepackage{etoolbox}
 \patchcmd{\maketitle}
   {\section{\normalfont\normalsize\abstractname}}
   {\section*{\normalfont\normalsize\abstractname}}
   {}{\typeout{Failed to patch abstract.}}
+\patchcmd{\maketitle}
+  {\section{\protect\normalfont{\@title}}}
+  {\section*{\protect\normalfont{\@title}}}
+  {}{\typeout{Failed to patch title.}}
+\makeatother
 
 \usepackage{xpatch}
 \makeatletter


### PR DESCRIPTION
As discussed in #85, when in manuscript mode the abstract is numbered when setting `numbersections: yes`, which is probably undesirable in most cases. This PR should fix this.