### PR TITLE
throw an informative error message from wsci() if no within-subjects …

### DIFF
--- a/tests/testthat/test_calculations.R
+++ b/tests/testthat/test_calculations.R
@@ -118,6 +118,18 @@ test_that(
 )
 
 test_that(
+  "Within-subjects confidence intervals: Only between-subejcts factors"
+  , {
+    data <- npk
+    data$id <- seq_len(nrow(data))
+    expect_error(
+      wsci(data = data, id = "id", dv = "yield", factors = "N", method = "Morey")
+      , regexp = "No within-subjects factor"
+    )
+  }
+)
+
+test_that(
   "add_effect_sizes: Two-way between-subjects design"
   , {
     apa_variance_table <- structure(


### PR DESCRIPTION
…factor is specified.

There was a tiny glitch in `wsci()` that caused an exception before the proper error handling could kick in. Now throws an informative error message ("No within-subjects factor specified") instead of failing early. Behavior is now also tested