### PR TITLE
Solves issue #559

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ SystemRequirements: Rendering the document template requires
   such as TinyTeX (>= 0.12; https://yihui.org/tinytex/)
 License: MIT + file LICENSE
 Encoding: UTF-8
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr, R.rsp
 Language: en-US
 Roxygen: list(markdown = TRUE)

--- a/R/apa_num.R
+++ b/R/apa_num.R
@@ -430,12 +430,13 @@ print_p <- apa_p
 #'   should be determined for each element of `x` separately (the default),
 #'   or for the complete vector `x`.
 #' @inherit apa_num return
+#' @inheritParams base::formatC
 #' @seealso [apa_num()], [apa_p()]
 #' @examples
 #' apa_df(c(1, 1.23151))
 #' @export
 
-apa_df <- function(x, digits = 2L, elementwise = TRUE) {
+apa_df <- function(x, digits = 2L, big.mark = "", elementwise = TRUE) {
 
   if(is.null(x))    return(NULL)
   if(is.integer(x)) return(apa_num(x))
@@ -455,7 +456,7 @@ apa_df <- function(x, digits = 2L, elementwise = TRUE) {
     digits <- 0L
   }
 
-  apa_num(x, digits = digits)
+  apa_num(x, digits = digits, big.mark = big.mark)
 }
 
 #' @rdname apa_df

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,8 @@
+# Upcoming release
+
+- Degrees of freedom are now (as a new default) reported without a comma as a big mark, resolves #559 reported by @Fritz-theCat.
+
+
 # papaja 0.1.1
 
 - Maintenance update: Adjusted unit tests to avoid removal from CRAN

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,6 +1,6 @@
 # papaja 0.1.1
 
-- Maintenance update: Adjuted unit tests to avoid removal from CRAN
+- Maintenance update: Adjusted unit tests to avoid removal from CRAN
 
 # papaja 0.1.0
 

--- a/man/apa_df.Rd
+++ b/man/apa_df.Rd
@@ -5,15 +5,19 @@
 \alias{print_df}
 \title{Typeset Degrees of Freedom}
 \usage{
-apa_df(x, digits = 2L, elementwise = TRUE)
+apa_df(x, digits = 2L, big.mark = "", elementwise = TRUE)
 
-print_df(x, digits = 2L, elementwise = TRUE)
+print_df(x, digits = 2L, big.mark = "", elementwise = TRUE)
 }
 \arguments{
 \item{x}{Numeric. The degrees of freedom to report.}
 
 \item{digits}{Integer. The desired number of digits after the decimal point to
 be used if \code{x} contains non-integer values.}
+
+\item{big.mark}{character; if not empty used as mark between every
+    \code{big.interval} decimals \emph{before} (hence \code{big}) the
+    decimal point.}
 
 \item{elementwise}{Logical. Determines whether the number of trailing digits
 should be determined for each element of \code{x} separately (the default),

--- a/tests/testthat/test_apa_num.R
+++ b/tests/testthat/test_apa_num.R
@@ -268,3 +268,19 @@ test_that(
     )
   }
 )
+
+test_that(
+  "apa_df() respects big.mark"
+  , {
+    # default
+    expect_identical(
+      apa_df(1e4)
+      , "10000"
+    )
+    # with other argument
+    expect_identical(
+      apa_df(1e4, big.mark = "{,}")
+      , "10{,}000"
+    )
+  }
+)


### PR DESCRIPTION
With these changes, degrees of freedom are now reported without a comma as a big mark. However, it is now also possible to specify `big.mark = "anything else"`.