### PR TITLE
Removes outdated test for apa_table(). Fixes #563

### DIFF
--- a/tests/testthat/test_apa_table.R
+++ b/tests/testthat/test_apa_table.R
@@ -16,8 +16,6 @@ test_that(
         , Max = apa_num( max(Recall) )
       )
 
-    expect_error(x <- capture.output(apa_table(descriptives, added_colnames = letters[1:5])))
-
     skip_on_cran()
     rmarkdown::render(
       "test_apa_table.Rmd"


### PR DESCRIPTION
As pointed out by @yihui, there we had an outdated test for `apa_table()` that is no longer required because the tested argument has been removed. 

As reported in #563, this test is causing issues for the development version of `knitr`.

This PR removes the test and should resolve the issue in `knitr`. The tests are failing due to an unrelated issue.