### PR TITLE
Added minimum sufficient input validation to `add_mse()`

### DIFF
--- a/R/calculations.R
+++ b/R/calculations.R
@@ -452,6 +452,10 @@ add_effect_sizes <- function(x, es = "ges", observed = NULL, intercept = FALSE) 
 #' @keywords internal
 
 add_mse <- function(x) {
+  if(!inherits(x, "data.frame")) {
+    stop("The first argument to add_mse() must inherit from class 'data.frame', but ", encodeString(deparse(substitute(x)), quote = "'"), " does not.")
+  }
+
   if(!is.null(x$sumsq_err) & !is.null(x$df.residual)) {
     x$mse <- x$sumsq_err / x$df.residual
     tinylabels::variable_label(x$mse) <- "$\\mathit{MSE}$"

--- a/tests/testthat/test_calculations.R
+++ b/tests/testthat/test_calculations.R
@@ -363,8 +363,10 @@ test_that(
 )
 
 test_that(
-  "add_mse(): Warn if information is not sufficient"
+  "add_mse(): Warn if information is not sufficient, error if x is not a data frame"
   , {
-    expect_warning(papaja:::add_mse(data.frame()))
+    object <- 1:4
+    expect_error(add_mse(object), "The first argument to add_mse() must inherit from class 'data.frame', but 'object' does not.", fixed = TRUE)
+    expect_warning(add_mse(data.frame()), "Mean-squared errors requested, but necessary information not available.", fixed = TRUE)
   }
 )


### PR DESCRIPTION
I think the only necessary condition for `add_mse()` to work is that its first argument inherits from class `data.frame`, so this is exactly what we are checking here, now.

Question: Why not use `validate(x, check_class = "data.frame")`?
Answer: "Error in validate(object, check_class = "data.frame"): ..." is not as informative as "Error in add_mse(object): ...".
