### PR TITLE
fixes #576

### DIFF
--- a/R/apa_print_htest.R
+++ b/R/apa_print_htest.R
@@ -131,6 +131,9 @@ apa_print.htest <- function(
     x_list
     , stringsAsFactors = FALSE
   )
+  y$number.of.successes <- NULL
+  y$number.of.trials <- NULL
+
   if(!identical(conf_int, list(NULL))) y$conf.int <- conf_int
 
   # sanitize table ----

--- a/R/lookup_tables.R
+++ b/R/lookup_tables.R
@@ -47,6 +47,8 @@ lookup_names <- c(
   , "delta"                     = "estimate"
   , "proportion"                = "estimate"
   , "p"                         = "estimate"
+  # binomial test:
+  , "probability.of.success"    = "estimate"
   # estimate from effectsize package
   , "Eta2"             = "estimate"
   , "Eta2_partial"     = "estimate"
@@ -167,6 +169,7 @@ lookup_labels <- c(
   , "difference.in.proportions" = "$\\Delta \\hat\\pi$"
   , "proportion"                = "$\\hat\\pi$"
   , "p"                         = "$\\hat\\pi$"
+  , "probability.of.success"    = "$\\hat\\pi$"
   , "delta"                     = "$\\delta$"
   # estimate from effectsize package
   , "Eta2"             = "$\\hat{\\eta}^2$"

--- a/man/lookup_tables.Rd
+++ b/man/lookup_tables.Rd
@@ -7,9 +7,9 @@
 \alias{lookup_adjust_names}
 \title{Lookup Tables for Column Names and Variable Labels}
 \format{
-An object of class \code{character} of length 107.
+An object of class \code{character} of length 108.
 
-An object of class \code{character} of length 102.
+An object of class \code{character} of length 103.
 }
 \usage{
 lookup_names

--- a/tests/testthat/test_apa_print_htest.R
+++ b/tests/testthat/test_apa_print_htest.R
@@ -307,6 +307,22 @@ test_that(
 )
 
 test_that(
+  "Binomial test"
+  , {
+    binom_test_output <- binom.test(10, 20, p = .8, conf.level = .9) |>
+      papaja::apa_print()
+    expect_apa_results(
+      binom_test_output
+      , labels = list(
+        estimate   = "$\\hat\\pi$"
+        , conf.int = "90\\% CI"
+        , p.value  = "$p$"
+      )
+    )
+  }
+)
+
+test_that(
   "Bartlett test"
   , {
     bartlett_test <- bartlett.test(count ~ spray, data = InsectSprays)


### PR DESCRIPTION
Hi @crsh,

I think `apa_print()` actually never worked for output from `binom.test()`. This PR adds support for `binom.test()`. I call the estimate `$\\hat\\pi$` (not *p*) to avoid confusion with the *p* value and remove *k* and *n* from the output.