### PR TITLE
Fixing write_bib for packages with multiple citation entries

### DIFF
--- a/R/r_refs.R
+++ b/R/r_refs.R
@@ -102,7 +102,7 @@ create_bib <- function(x, file, append = TRUE, prefix = "R-", type_pref = c("Art
         bibtypes <- unlist(cite$bibtype)
 
         pref_entry <- type_pref[tolower(type_pref) %in% tolower(bibtypes)][1]
-        cite <- if(is.na(pref_entry)) cite[[1]] else cite[[which(bibtypes == pref_entry)]]
+        cite <- if(is.na(pref_entry)) cite[[1]] else cite[[which(bibtypes %in% pref_entry)]]
       }
 
       if(tweak) {


### PR DESCRIPTION
Addressing [issue 608](https://github.com/crsh/papaja/issues/608).

Currently, papaja::r_ref or create_bib fails for me for any package with more than one citation entry. This should address that issue. Tested locally.
