### PR TITLE
Add intercept parameter to add_custom_effect_sizes.function

### DIFF
--- a/R/add_custom_effect_sizes.R
+++ b/R/add_custom_effect_sizes.R
@@ -68,6 +68,7 @@ add_custom_effect_sizes.function <- function(estimate, canonical_table, intercep
   add_custom_effect_sizes(
     estimate = do.call(what = estimate, args = estimate_args)
     , canonical_table = canonical_table
+    , intercept = intercept
     , .x = .x
     , ...
   )


### PR DESCRIPTION
For ANOVA, intercept terms are omitted even if `intercept = TRUE`, when a custom effect size function is passed. This also affects the default behavior, when *effectsize* is installed.

```r
library("afex")
library("papaja")

data(md_12.1)
md_12_aov <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"), 
       anova_table=list(intercept = TRUE))

custom_eta_squared <- \(x) effectsize::eta_squared(
  x
  , generalized = TRUE
  , include_intercept = TRUE
  , alternative = "two.sided"
  , ci = 0.90
)

apa_print(md_12_aov, estimate = "ges", intercept = TRUE)$table
apa_print(md_12_aov, intercept = TRUE)$table
apa_print(md_12_aov, intercept = TRUE, estimate = custom_eta_squared)$table
```

Add intercept parameter to `add_custom_effect_sizes.function` fixes this.