### PR TITLE
Fix apa_num.integer() to honor big.mark formatting

### DIFF
--- a/R/apa_num.R
+++ b/R/apa_num.R
@@ -95,7 +95,15 @@ apa_num.integer <- function(x, numerals = TRUE, capitalize = FALSE, zero_string 
   if(!is.null(system_call[["zero"]]) && is.null(system_call[["zero_string"]])) zero_string <- "no"
   validate(zero_string, check_class = "character", check_length = 1)
 
-  if(numerals) return(as.character(x))
+  if(numerals) {
+    formatting_args <- c("big.mark", "decimal.mark", "format", "digits", "width", "flag")
+    if(any(names(list(...)) %in% formatting_args)) {
+      ellipsis <- list(...)
+      ellipsis$x <- x
+      return(do.call("formatC", ellipsis))
+    }
+    return(as.character(x))
+  }
   if(anyNA(x)) return(rep(na_string, length(x)))
 
   zero_string <- tolower(zero_string)


### PR DESCRIPTION
When numerals = TRUE (the default), apa_num.integer() returned as.character(x) immediately and never checked for formatting arguments like big.mark. So apa_num(7000L, big.mark = ",") returned "7000" instead of "7,000". Now if any formatC arguments are present in ..., the function routes to formatC instead of short-circuiting.
